### PR TITLE
feat: config-driven multi-provider embeddings + ingest robustness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ EMBEDDING_PROVIDER=ollama
 OLLAMA_HOST=localhost
 OLLAMA_PORT=11434
 EMBEDDING_MODEL=bge-m3
+# Head-truncate embedding input to this many chars (models have a fixed context
+# window and error on overflow). On overflow the input is halved and retried.
+EMBEDDING_MAX_CHARS=8000
 # EMBEDDING_DIMENSIONS is auto-detected from model name if not set:
 #   - nomic-embed-text: 768
 #   - qwen3-embedding: 1024

--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,18 @@ POSTGRES_PASSWORD=mindbase_dev
 POSTGRES_DB=mindbase_dev
 POSTGRES_INTERNAL_PORT=5432
 
+# Embedding provider: "ollama" (local, default) | "openai".
+# Explicit, config-driven — switch to compare retrieval quality. Per-provider
+# vectors coexist in conversation_embeddings, so changing this does not destroy
+# the other provider's embeddings; use POST /conversations/reembed to backfill.
+EMBEDDING_PROVIDER=ollama
+
 # Ollama Configuration
+# For the self-hosted k3s Ollama (NodePort over Tailscale), set:
+#   OLLAMA_URL=http://<agile-server-tailscale-ip>:31434
 OLLAMA_HOST=localhost
 OLLAMA_PORT=11434
-EMBEDDING_MODEL=qwen3-embedding:8b
+EMBEDDING_MODEL=bge-m3
 # EMBEDDING_DIMENSIONS is auto-detected from model name if not set:
 #   - nomic-embed-text: 768
 #   - qwen3-embedding: 1024

--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -14,10 +14,12 @@ from app.schemas.conversation import (
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
+    ReembedRequest,
+    ReembedResponse,
     SearchQuery,
     SearchResult,
 )
-from app.services.deriver import process_raw_conversation
+from app.services.deriver import _extract_text_from_content, process_raw_conversation
 
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 logger = logging.getLogger(__name__)
@@ -78,18 +80,26 @@ async def search_conversations_endpoint(
     """
     Semantic search across conversations
 
-    - Generates query embedding using OpenAI text-embedding-3-large (Ollama fallback)
-    - Performs vector similarity search with pgvector
-    - Returns ranked results by similarity
+    - Embeds the query with the requested (or active) provider/model
+    - Scans that provider/model's vectors in conversation_embeddings
+    - Returns ranked results by similarity. Pass `provider`/`model` to compare
+      providers over the same query.
     """
     try:
-        # Generate query embedding
-        query_embedding = await ollama_client.embed(query.query)
+        # Resolve provider/model: the query must be embedded with the same model
+        # whose stored vectors we search against.
+        provider = query.provider or ollama_client.active_provider
+        model = query.model or ollama_client.default_model(provider)
 
-        # Search conversations
-        results = await crud.search_conversations(
+        query_embedding = await ollama_client.embed(
+            query.query, provider=provider, model=model
+        )
+
+        results = await crud.search_conversation_embeddings(
             db=db,
             query_embedding=query_embedding,
+            provider=provider,
+            model=model,
             limit=query.limit,
             threshold=query.threshold,
             source=query.source,
@@ -136,3 +146,51 @@ async def search_conversations_endpoint(
     except Exception as exc:  # pragma: no cover
         logger.exception("Failed to search conversations")
         raise HTTPException(status_code=500, detail=f"Search failed: {exc}") from exc
+
+
+@router.post("/reembed", response_model=ReembedResponse)
+async def reembed_conversations(
+    request: ReembedRequest, db: AsyncSession = Depends(get_db)
+):
+    """
+    Backfill embeddings for an existing corpus with another provider/model.
+
+    Conversations are ingested under the active provider only. To compare a
+    second provider, call this to embed conversations that don't yet have a
+    vector for the given provider/model. Idempotent: only missing ones are
+    embedded, so it can be called repeatedly until `remaining` reaches 0.
+    """
+    try:
+        model = request.model or ollama_client.default_model(request.provider)
+
+        pending = await crud.list_conversations_missing_embedding(
+            db, provider=request.provider, model=model, limit=request.limit
+        )
+
+        embedded = 0
+        for row in pending:
+            text_content, _, _ = _extract_text_from_content(row["content"])
+            vector = await ollama_client.embed(
+                text_content or " ", provider=request.provider, model=model
+            )
+            await crud.upsert_conversation_embedding(
+                db, row["id"], request.provider, model, vector
+            )
+            embedded += 1
+
+        await db.commit()
+
+        remaining = await crud.count_conversations_missing_embedding(
+            db, provider=request.provider, model=model
+        )
+
+        return ReembedResponse(
+            provider=request.provider,
+            model=model,
+            embedded=embedded,
+            remaining=remaining,
+        )
+
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Failed to reembed conversations")
+        raise HTTPException(status_code=500, detail=f"Reembed failed: {exc}") from exc

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -15,11 +15,17 @@ class Settings(BaseSettings):
     # Database - REQUIRED from environment
     DATABASE_URL: str
 
-    # OpenAI Embedding (primary)
+    # Embedding provider selection: "ollama" | "openai".
+    # Explicit and config-driven — no implicit key-presence fallback. The active
+    # provider decides which embedder store/search use; per-provider vectors
+    # coexist in conversation_embeddings so providers can be compared.
+    EMBEDDING_PROVIDER: str = "ollama"
+
+    # OpenAI Embedding
     OPENAI_API_KEY: str | None = None
     OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-large"
 
-    # Ollama Embedding (fallback)
+    # Ollama Embedding
     OLLAMA_URL: str
     EMBEDDING_MODEL: str
     EMBEDDING_DIMENSIONS: int

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
     EMBEDDING_MODEL: str
     EMBEDDING_DIMENSIONS: int
 
+    # Max characters of input text per embedding call. Embedding models have a
+    # fixed context window (bge-m3: 8192 tokens) and error on overflow, so long
+    # transcripts are head-truncated to this budget before embedding. ~8000
+    # chars stays safely under 8192 tokens across Japanese/English/code.
+    EMBEDDING_MAX_CHARS: int = 8000
+
     # API
     DEBUG: bool = False
     API_TITLE: str = "MindBase API"

--- a/apps/api/crud/__init__.py
+++ b/apps/api/crud/__init__.py
@@ -5,9 +5,21 @@ from app.crud.conversation import (
     create_raw_conversation,
 )
 from app.crud.search import search_conversations
+from app.crud.embeddings import (
+    column_for_dim,
+    count_conversations_missing_embedding,
+    list_conversations_missing_embedding,
+    search_conversation_embeddings,
+    upsert_conversation_embedding,
+)
 
 __all__ = [
     "create_raw_conversation",
     "create_conversation_record",
     "search_conversations",
+    "column_for_dim",
+    "count_conversations_missing_embedding",
+    "list_conversations_missing_embedding",
+    "search_conversation_embeddings",
+    "upsert_conversation_embedding",
 ]

--- a/apps/api/crud/conversation.py
+++ b/apps/api/crud/conversation.py
@@ -40,7 +40,7 @@ async def create_conversation_record(
     conversation: ConversationCreate,
     *,
     raw_record: RawConversation,
-    embedding: List[float],
+    embedding: Optional[List[float]] = None,
     workspace_path: Optional[str],
     message_count: int,
     raw_content: Optional[str],

--- a/apps/api/crud/embeddings.py
+++ b/apps/api/crud/embeddings.py
@@ -41,11 +41,14 @@ async def upsert_conversation_embedding(
     """Insert or replace the embedding for one (conversation, provider, model)."""
     dim = len(vector)
     col = column_for_dim(dim)
+    # id is supplied here (gen_random_uuid) rather than relying on a column
+    # default: the table is created from the SQLAlchemy model, whose id default
+    # is Python-side (uuid.uuid4) and does not apply to this raw INSERT.
     stmt = text(
         f"""
         INSERT INTO conversation_embeddings
-            (conversation_id, provider, model, dim, {col})
-        VALUES (:cid, :provider, :model, :dim, CAST(:vec AS vector))
+            (id, conversation_id, provider, model, dim, {col})
+        VALUES (gen_random_uuid(), :cid, :provider, :model, :dim, CAST(:vec AS vector))
         ON CONFLICT (conversation_id, provider, model)
         DO UPDATE SET {col} = EXCLUDED.{col}, dim = EXCLUDED.dim, created_at = NOW()
         """

--- a/apps/api/crud/embeddings.py
+++ b/apps/api/crud/embeddings.py
@@ -44,15 +44,13 @@ async def upsert_conversation_embedding(
     # id is supplied here (gen_random_uuid) rather than relying on a column
     # default: the table is created from the SQLAlchemy model, whose id default
     # is Python-side (uuid.uuid4) and does not apply to this raw INSERT.
-    stmt = text(
-        f"""
+    stmt = text(f"""
         INSERT INTO conversation_embeddings
             (id, conversation_id, provider, model, dim, {col})
         VALUES (gen_random_uuid(), :cid, :provider, :model, :dim, CAST(:vec AS vector))
         ON CONFLICT (conversation_id, provider, model)
         DO UPDATE SET {col} = EXCLUDED.{col}, dim = EXCLUDED.dim, created_at = NOW()
-        """
-    )
+        """)
     await db.execute(
         stmt,
         {
@@ -72,8 +70,7 @@ async def list_conversations_missing_embedding(
     limit: int = 500,
 ) -> List[dict]:
     """Return conversations that have no embedding for the given provider/model."""
-    stmt = text(
-        """
+    stmt = text("""
         SELECT c.id, c.content, c.raw_content
         FROM conversations c
         WHERE NOT EXISTS (
@@ -84,8 +81,7 @@ async def list_conversations_missing_embedding(
         )
         ORDER BY c.created_at DESC
         LIMIT :limit
-        """
-    )
+        """)
     result = await db.execute(
         stmt, {"provider": provider, "model": model, "limit": limit}
     )
@@ -98,8 +94,7 @@ async def count_conversations_missing_embedding(
     model: str,
 ) -> int:
     """Count conversations with no embedding for the given provider/model."""
-    stmt = text(
-        """
+    stmt = text("""
         SELECT COUNT(*)
         FROM conversations c
         WHERE NOT EXISTS (
@@ -108,8 +103,7 @@ async def count_conversations_missing_embedding(
               AND e.provider = :provider
               AND e.model = :model
         )
-        """
-    )
+        """)
     result = await db.execute(stmt, {"provider": provider, "model": model})
     return int(result.scalar() or 0)
 

--- a/apps/api/crud/embeddings.py
+++ b/apps/api/crud/embeddings.py
@@ -1,0 +1,206 @@
+"""CRUD for the multi-provider conversation_embeddings table.
+
+Each (conversation, provider, model) row stores its vector in the
+dimension-bucket column matching the vector length, so providers with different
+dimensions coexist. Search is an exact cosine scan (no ANN index — see the
+migration for why), filtered to one provider/model so the query embedding and
+the stored vectors come from the same model.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.conversation import EMBEDDING_DIM_COLUMNS
+
+DEFAULT_RECENCY_WEIGHT = 0.15
+
+
+def column_for_dim(dim: int) -> str:
+    """Return the vector column name for an embedding dimension."""
+    try:
+        return EMBEDDING_DIM_COLUMNS[dim]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported embedding dimension {dim}. Add a vec_{dim} column to "
+            "conversation_embeddings (migration) and EMBEDDING_DIM_COLUMNS to "
+            "support this model."
+        ) from exc
+
+
+async def upsert_conversation_embedding(
+    db: AsyncSession,
+    conversation_id,
+    provider: str,
+    model: str,
+    vector: Sequence[float],
+) -> None:
+    """Insert or replace the embedding for one (conversation, provider, model)."""
+    dim = len(vector)
+    col = column_for_dim(dim)
+    stmt = text(
+        f"""
+        INSERT INTO conversation_embeddings
+            (conversation_id, provider, model, dim, {col})
+        VALUES (:cid, :provider, :model, :dim, CAST(:vec AS vector))
+        ON CONFLICT (conversation_id, provider, model)
+        DO UPDATE SET {col} = EXCLUDED.{col}, dim = EXCLUDED.dim, created_at = NOW()
+        """
+    )
+    await db.execute(
+        stmt,
+        {
+            "cid": str(conversation_id),
+            "provider": provider,
+            "model": model,
+            "dim": dim,
+            "vec": str(list(vector)),
+        },
+    )
+
+
+async def list_conversations_missing_embedding(
+    db: AsyncSession,
+    provider: str,
+    model: str,
+    limit: int = 500,
+) -> List[dict]:
+    """Return conversations that have no embedding for the given provider/model."""
+    stmt = text(
+        """
+        SELECT c.id, c.content, c.raw_content
+        FROM conversations c
+        WHERE NOT EXISTS (
+            SELECT 1 FROM conversation_embeddings e
+            WHERE e.conversation_id = c.id
+              AND e.provider = :provider
+              AND e.model = :model
+        )
+        ORDER BY c.created_at DESC
+        LIMIT :limit
+        """
+    )
+    result = await db.execute(
+        stmt, {"provider": provider, "model": model, "limit": limit}
+    )
+    return [dict(row._mapping) for row in result.fetchall()]
+
+
+async def count_conversations_missing_embedding(
+    db: AsyncSession,
+    provider: str,
+    model: str,
+) -> int:
+    """Count conversations with no embedding for the given provider/model."""
+    stmt = text(
+        """
+        SELECT COUNT(*)
+        FROM conversations c
+        WHERE NOT EXISTS (
+            SELECT 1 FROM conversation_embeddings e
+            WHERE e.conversation_id = c.id
+              AND e.provider = :provider
+              AND e.model = :model
+        )
+        """
+    )
+    result = await db.execute(stmt, {"provider": provider, "model": model})
+    return int(result.scalar() or 0)
+
+
+async def search_conversation_embeddings(
+    db: AsyncSession,
+    query_embedding: List[float],
+    provider: str,
+    model: str,
+    limit: int = 10,
+    threshold: float = 0.8,
+    source: Optional[str] = None,
+    project: Optional[str] = None,
+    topic: Optional[str] = None,
+    workspace_path: Optional[str] = None,
+    recency_weight: float = DEFAULT_RECENCY_WEIGHT,
+    recency_tau_seconds: int = 1209600,  # 14 days
+    recency_boost_days: int = 3,
+    recency_boost_value: float = 0.05,
+):
+    """Search one provider/model's embeddings with recency-weighted ranking.
+
+    Mirrors crud.search.search_conversations' scoring, but scans the
+    per-provider conversation_embeddings table joined back to conversations.
+    """
+    col = column_for_dim(len(query_embedding))
+
+    semantic_w = 1.0 - recency_weight
+    recency_w = recency_weight
+    weight_sum = semantic_w + recency_w
+    if weight_sum <= 0:
+        semantic_w = 1.0 - DEFAULT_RECENCY_WEIGHT
+        recency_w = DEFAULT_RECENCY_WEIGHT
+    else:
+        semantic_w /= weight_sum
+        recency_w /= weight_sum
+
+    safe_tau_seconds = max(1, recency_tau_seconds)
+    safe_boost_days = max(0, recency_boost_days)
+    safe_boost_value = max(0.0, min(1.0, recency_boost_value))
+
+    sim = f"GREATEST(0, 1 - (e.{col} <=> CAST(:embedding AS vector)))"
+    recency = (
+        "LEAST(1.0, EXP(-EXTRACT(EPOCH FROM (NOW() - "
+        "COALESCE(c.created_at, to_timestamp(0)))) / :tau_seconds) + CASE WHEN "
+        "c.created_at >= NOW() - (:boost_days * INTERVAL '1 day') THEN :boost_value "
+        "ELSE 0 END)"
+    )
+
+    query_text = f"""
+    SELECT c.*,
+           {sim} AS semantic_score,
+           {recency} AS recency_score,
+           ({sim} * :semantic_weight + {recency} * :recency_weight) AS combined_score,
+           {sim} AS similarity
+    FROM conversation_embeddings e
+    JOIN conversations c ON c.id = e.conversation_id
+    WHERE e.provider = :provider
+          AND e.model = :model
+          AND e.{col} IS NOT NULL
+          AND {sim} >= :threshold
+    """
+
+    if source:
+        query_text += " AND c.source = :source"
+    if project:
+        query_text += " AND c.project = :project"
+    if topic:
+        query_text += " AND c.topics IS NOT NULL AND :topic = ANY(c.topics)"
+    if workspace_path:
+        query_text += " AND c.workspace_path = :workspace_path"
+
+    query_text += " ORDER BY combined_score DESC LIMIT :limit"
+
+    params: dict = {
+        "embedding": str(query_embedding),
+        "provider": provider,
+        "model": model,
+        "threshold": threshold,
+        "limit": limit,
+        "tau_seconds": safe_tau_seconds,
+        "boost_days": safe_boost_days,
+        "boost_value": safe_boost_value,
+        "semantic_weight": semantic_w,
+        "recency_weight": recency_w,
+    }
+    if source:
+        params["source"] = source
+    if project:
+        params["project"] = project
+    if topic:
+        params["topic"] = topic
+    if workspace_path:
+        params["workspace_path"] = workspace_path
+
+    result = await db.execute(text(query_text), params)
+    return result.fetchall()

--- a/apps/api/models/conversation.py
+++ b/apps/api/models/conversation.py
@@ -108,3 +108,51 @@ class Conversation(Base):
 
     def __repr__(self) -> str:  # pragma: no cover - repr helper
         return f"<Conversation(id={self.id}, source={self.source}, title={self.title})>"
+
+
+# Dimension-bucket columns on ConversationEmbedding, keyed by vector length.
+# A row fills exactly one of these (the one matching its provider/model dim).
+EMBEDDING_DIM_COLUMNS = {768: "vec_768", 1024: "vec_1024", 3072: "vec_3072", 4096: "vec_4096"}
+
+
+class ConversationEmbedding(Base):
+    """One embedding per (conversation, provider, model).
+
+    Vectors from different models have different dimensions and are not
+    comparable, so each row stores its vector in the dimension-bucket column
+    matching its length. This lets OpenAI, bge-m3, qwen3-embedding, etc. coexist
+    for the same conversation so providers can be compared. See migration
+    20260606000000_conversation_embeddings.sql.
+    """
+
+    __tablename__ = "conversation_embeddings"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    provider = Column(String, nullable=False)
+    model = Column(String, nullable=False)
+    dim = Column(Integer, nullable=False)
+    vec_768 = Column(Vector(768))
+    vec_1024 = Column(Vector(1024))
+    vec_3072 = Column(Vector(3072))
+    vec_4096 = Column(Vector(4096))
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "conversation_id",
+            "provider",
+            "model",
+            name="conversation_embeddings_conversation_id_provider_model_key",
+        ),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - repr helper
+        return (
+            f"<ConversationEmbedding(conversation_id={self.conversation_id}, "
+            f"provider={self.provider}, model={self.model}, dim={self.dim})>"
+        )

--- a/apps/api/models/conversation.py
+++ b/apps/api/models/conversation.py
@@ -112,7 +112,12 @@ class Conversation(Base):
 
 # Dimension-bucket columns on ConversationEmbedding, keyed by vector length.
 # A row fills exactly one of these (the one matching its provider/model dim).
-EMBEDDING_DIM_COLUMNS = {768: "vec_768", 1024: "vec_1024", 3072: "vec_3072", 4096: "vec_4096"}
+EMBEDDING_DIM_COLUMNS = {
+    768: "vec_768",
+    1024: "vec_1024",
+    3072: "vec_3072",
+    4096: "vec_4096",
+}
 
 
 class ConversationEmbedding(Base):

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -1,4 +1,10 @@
-"""Embedding client with OpenAI primary + Ollama fallback.
+"""Embedding client with explicit, config-driven provider selection.
+
+The active provider is chosen by ``settings.EMBEDDING_PROVIDER`` ("ollama" |
+"openai") — there is no implicit key-presence fallback and no silent switch on
+error: a failing provider raises so misconfiguration is visible. ``embed`` and
+``embed_batch`` accept ``provider`` / ``model`` overrides so the same text can be
+embedded by a different provider for side-by-side comparison.
 
 Model management (pull, delete, list) is delegated to services/model_manager.py.
 """
@@ -6,7 +12,7 @@ Model management (pull, delete, list) is delegated to services/model_manager.py.
 from __future__ import annotations
 
 import logging
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 import httpx
 
@@ -15,12 +21,16 @@ from app.services.model_manager import ModelManager
 
 logger = logging.getLogger(__name__)
 
+OPENAI = "openai"
+OLLAMA = "ollama"
+
 
 class EmbeddingClient:
-    """Async embedding client that uses OpenAI API (primary) with Ollama fallback."""
+    """Async embedding client with an explicit, config-selected provider."""
 
     def __init__(
         self,
+        provider: str | None = None,
         openai_api_key: str | None = None,
         openai_model: str | None = None,
         ollama_url: str | None = None,
@@ -28,45 +38,62 @@ class EmbeddingClient:
         timeout: float = 60.0,
     ) -> None:
         settings = get_settings()
+        self.provider = (provider or settings.EMBEDDING_PROVIDER or OLLAMA).lower()
         self.openai_api_key = openai_api_key or settings.OPENAI_API_KEY
         self.openai_model = openai_model or settings.OPENAI_EMBEDDING_MODEL
         self.ollama_url = (ollama_url or settings.OLLAMA_URL).rstrip("/")
         self.ollama_model = ollama_model or settings.EMBEDDING_MODEL
         self.timeout = timeout
 
-        self._provider = "openai" if self.openai_api_key else "ollama"
         logger.info(
-            "Embedding provider: %s (model: %s)",
-            self._provider,
-            self.openai_model if self._provider == "openai" else self.ollama_model,
+            "Embedding provider: %s (model: %s)", self.provider, self.active_model
         )
 
         # Delegate model management
         self._model_manager = ModelManager(ollama_url=self.ollama_url, timeout=timeout)
 
+    # ------------------------------------------------------------------ helpers
+    @property
+    def active_provider(self) -> str:
+        return self.provider
+
+    def default_model(self, provider: str) -> str:
+        """Return the configured default model for a provider."""
+        return self.openai_model if provider == OPENAI else self.ollama_model
+
+    @property
+    def active_model(self) -> str:
+        return self.default_model(self.provider)
+
     @property
     def model(self) -> str:
-        """Return the active model name."""
-        if self._provider == "openai":
-            return self.openai_model
-        return self.ollama_model
+        """Active model name (kept for the embeddings management route)."""
+        return self.active_model
 
     @model.setter
     def model(self, value: str) -> None:
-        """Set the active model (for backward compatibility with embeddings route)."""
-        if self._provider == "openai":
+        if self.provider == OPENAI:
             self.openai_model = value
         else:
             self.ollama_model = value
 
-    async def _openai_embed(self, texts: List[str]) -> List[List[float]]:
-        """Generate embeddings using OpenAI API."""
+    def _resolve(self, provider: str | None, model: str | None) -> Tuple[str, str]:
+        prov = (provider or self.provider).lower()
+        return prov, (model or self.default_model(prov))
+
+    # ------------------------------------------------------------------ backends
+    async def _openai_embed(self, texts: List[str], model: str) -> List[List[float]]:
+        """Generate embeddings using the OpenAI API."""
+        if not self.openai_api_key:
+            raise RuntimeError(
+                "Embedding provider 'openai' selected but OPENAI_API_KEY is not set"
+            )
         url = "https://api.openai.com/v1/embeddings"
         headers = {
             "Authorization": f"Bearer {self.openai_api_key}",
             "Content-Type": "application/json",
         }
-        payload = {"model": self.openai_model, "input": texts}
+        payload = {"model": model, "input": texts}
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(url, json=payload, headers=headers)
@@ -76,10 +103,10 @@ class EmbeddingClient:
         sorted_data = sorted(data["data"], key=lambda x: x["index"])
         return [item["embedding"] for item in sorted_data]
 
-    async def _ollama_embed(self, text: str) -> List[float]:
-        """Generate embedding using Ollama API (single text)."""
+    async def _ollama_embed(self, text: str, model: str) -> List[float]:
+        """Generate an embedding using the Ollama API (single text)."""
         url = f"{self.ollama_url}/api/embeddings"
-        payload = {"model": self.ollama_model, "prompt": text}
+        payload = {"model": model, "prompt": text}
 
         async with httpx.AsyncClient(timeout=300.0) as client:
             response = await client.post(url, json=payload)
@@ -91,55 +118,51 @@ class EmbeddingClient:
             raise ValueError("Embedding not returned by Ollama")
         return embedding
 
-    async def embed(self, text: str) -> List[float]:
-        """Generate an embedding vector for the supplied text."""
-        if self._provider == "openai":
-            try:
-                results = await self._openai_embed([text])
-                return results[0]
-            except Exception as exc:
-                logger.warning(
-                    "OpenAI embedding failed, falling back to Ollama: %s", exc
-                )
-                self._provider = "ollama"
+    # ------------------------------------------------------------------- public
+    async def embed(
+        self, text: str, provider: str | None = None, model: str | None = None
+    ) -> List[float]:
+        """Embed a single text with the active (or overridden) provider/model."""
+        prov, mdl = self._resolve(provider, model)
+        if prov == OPENAI:
+            results = await self._openai_embed([text], mdl)
+            return results[0]
+        if prov == OLLAMA:
+            return await self._ollama_embed(text, mdl)
+        raise ValueError(f"Unknown embedding provider: {prov!r}")
 
-        return await self._ollama_embed(text)
-
-    async def embed_batch(self, texts: Iterable[str]) -> List[List[float]]:
-        """Generate embeddings for a collection of texts."""
+    async def embed_batch(
+        self,
+        texts: Iterable[str],
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> List[List[float]]:
+        """Embed a collection of texts with the active (or overridden) provider."""
         text_list = list(texts)
         if not text_list:
             return []
 
-        if self._provider == "openai":
-            try:
-                results: List[List[float]] = []
-                batch_size = 2048
-                for i in range(0, len(text_list), batch_size):
-                    batch = text_list[i : i + batch_size]
-                    batch_results = await self._openai_embed(batch)
-                    results.extend(batch_results)
-                return results
-            except Exception as exc:
-                logger.warning(
-                    "OpenAI batch embedding failed, falling back to Ollama: %s", exc
-                )
-                self._provider = "ollama"
-
-        embeddings: List[List[float]] = []
-        for text in text_list:
-            embeddings.append(await self._ollama_embed(text))
-        return embeddings
+        prov, mdl = self._resolve(provider, model)
+        if prov == OPENAI:
+            results: List[List[float]] = []
+            batch_size = 2048
+            for i in range(0, len(text_list), batch_size):
+                batch = text_list[i : i + batch_size]
+                results.extend(await self._openai_embed(batch, mdl))
+            return results
+        if prov == OLLAMA:
+            return [await self._ollama_embed(text, mdl) for text in text_list]
+        raise ValueError(f"Unknown embedding provider: {prov!r}")
 
     async def health_check(self) -> bool:
-        """Return True if the embedding service responds successfully."""
-        if self._provider == "openai":
+        """Return True if the active provider responds successfully."""
+        if self.provider == OPENAI:
             try:
-                await self._openai_embed(["test"])
+                await self._openai_embed(["test"], self.openai_model)
                 return True
-            except Exception as exc:
+            except Exception as exc:  # pragma: no cover - network dependent
                 logger.warning("OpenAI health check failed: %s", exc)
-
+                return False
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.get(f"{self.ollama_url}/api/version")
@@ -147,7 +170,7 @@ class EmbeddingClient:
         except httpx.HTTPError:
             return False
 
-    # Delegated model management
+    # --------------------------------------------------- delegated model mgmt
     async def list_models(self) -> List[str]:
         return await self._model_manager.list_models()
 
@@ -157,7 +180,7 @@ class EmbeddingClient:
     async def delete_model(self, model_name: str) -> bool:
         return await self._model_manager.delete_model(model_name)
 
-    # Compatibility wrappers
+    # ----------------------------------------------------- compatibility wraps
     async def generate_embedding(self, text: str) -> List[float]:
         return await self.embed(text)
 

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -43,6 +43,7 @@ class EmbeddingClient:
         self.openai_model = openai_model or settings.OPENAI_EMBEDDING_MODEL
         self.ollama_url = (ollama_url or settings.OLLAMA_URL).rstrip("/")
         self.ollama_model = ollama_model or settings.EMBEDDING_MODEL
+        self.max_chars = settings.EMBEDDING_MAX_CHARS
         self.timeout = timeout
 
         logger.info(
@@ -81,6 +82,10 @@ class EmbeddingClient:
         prov = (provider or self.provider).lower()
         return prov, (model or self.default_model(prov))
 
+    def _clip(self, text: str) -> str:
+        """Head-truncate to the model's context budget to avoid overflow errors."""
+        return text[: self.max_chars]
+
     # ------------------------------------------------------------------ backends
     async def _openai_embed(self, texts: List[str], model: str) -> List[List[float]]:
         """Generate embeddings using the OpenAI API."""
@@ -104,13 +109,28 @@ class EmbeddingClient:
         return [item["embedding"] for item in sorted_data]
 
     async def _ollama_embed(self, text: str, model: str) -> List[float]:
-        """Generate an embedding using the Ollama API (single text)."""
-        url = f"{self.ollama_url}/api/embeddings"
-        payload = {"model": model, "prompt": text}
+        """Generate an embedding using the Ollama API (single text).
 
+        Token density varies (dense JSON/base64 in tool messages can exceed the
+        model context even after the char-based clip), so on a context-length
+        overflow the input is halved and retried until it fits.
+        """
+        url = f"{self.ollama_url}/api/embeddings"
+        prompt = text
         async with httpx.AsyncClient(timeout=300.0) as client:
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
+            while True:
+                response = await client.post(
+                    url, json={"model": model, "prompt": prompt}
+                )
+                if (
+                    response.status_code == 500
+                    and "context length" in response.text
+                    and len(prompt) > 256
+                ):
+                    prompt = prompt[: len(prompt) // 2]
+                    continue
+                response.raise_for_status()
+                break
             data = response.json()
 
         embedding = data.get("embedding") or data.get("embeddings", [None])[0]
@@ -124,6 +144,7 @@ class EmbeddingClient:
     ) -> List[float]:
         """Embed a single text with the active (or overridden) provider/model."""
         prov, mdl = self._resolve(provider, model)
+        text = self._clip(text)
         if prov == OPENAI:
             results = await self._openai_embed([text], mdl)
             return results[0]
@@ -143,6 +164,7 @@ class EmbeddingClient:
             return []
 
         prov, mdl = self._resolve(provider, model)
+        text_list = [self._clip(t) for t in text_list]
         if prov == OPENAI:
             results: List[List[float]] = []
             batch_size = 2048

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -134,6 +134,16 @@ class SearchQuery(BaseModel):
     project: Optional[str] = Field(None, description="Filter by project identifier")
     topic: Optional[str] = Field(None, description="Filter by topic tag")
     workspace_path: Optional[str] = Field(None, description="Filter by workspace path")
+    provider: Optional[str] = Field(
+        None,
+        description="Embedding provider to search ('ollama'|'openai'); "
+        "defaults to the active EMBEDDING_PROVIDER",
+    )
+    model: Optional[str] = Field(
+        None,
+        description="Embedding model to search; defaults to the provider's "
+        "configured model. Must match a model already stored for comparison.",
+    )
 
     class Config:
         json_schema_extra = {
@@ -165,3 +175,30 @@ class SearchResult(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class ReembedRequest(BaseModel):
+    """Backfill embeddings for an existing corpus with another provider/model.
+
+    Used to populate a second provider's vectors over conversations that were
+    ingested under a different provider, so the two can be compared.
+    """
+
+    provider: str = Field(..., description="Embedding provider ('ollama'|'openai')")
+    model: Optional[str] = Field(
+        None, description="Model name; defaults to the provider's configured model"
+    )
+    limit: int = Field(
+        500, description="Max conversations to (re)embed in one call", ge=1, le=5000
+    )
+
+
+class ReembedResponse(BaseModel):
+    """Result of a reembed backfill run."""
+
+    provider: str
+    model: str
+    embedded: int = Field(..., description="Conversations embedded in this call")
+    remaining: int = Field(
+        ..., description="Conversations still missing this provider/model embedding"
+    )

--- a/apps/api/services/deriver.py
+++ b/apps/api/services/deriver.py
@@ -51,6 +51,12 @@ async def process_raw_conversation(
     text_content, message_count, raw_content = _extract_text_from_content(
         payload.content
     )
+    # Embed with the active provider. The vector is stored in
+    # conversation_embeddings (keyed by provider/model), not the legacy
+    # conversations.embedding column, so providers with different dimensions
+    # can coexist.
+    provider = ollama_client.active_provider
+    model = ollama_client.active_model
     embedding = await ollama_client.embed(text_content or " ")
 
     project = infer_project(
@@ -71,13 +77,15 @@ async def process_raw_conversation(
         db,
         payload,
         raw_record=raw_record,
-        embedding=embedding,
         workspace_path=workspace_path,
         message_count=message_count,
         raw_content=raw_content,
         project=project,
         topics=topics,
         metadata=metadata,
+    )
+    await crud.upsert_conversation_embedding(
+        db, conversation.id, provider, model, embedding
     )
 
     raw_record.processed_at = datetime.utcnow()

--- a/supabase/migrations/20260606000000_conversation_embeddings.sql
+++ b/supabase/migrations/20260606000000_conversation_embeddings.sql
@@ -1,0 +1,51 @@
+-- Migration: multi-provider conversation embeddings.
+--
+-- MindBase originally stored one embedding per conversation in
+-- conversations.embedding (a fixed vector(3072) for OpenAI text-embedding-3-large).
+-- A pgvector column has a fixed dimension and vectors from different models are
+-- not comparable, so that schema cannot hold embeddings from multiple providers
+-- at the same time.
+--
+-- This table holds one row per (conversation, provider, model). Each row fills
+-- exactly one dimension-bucket column so OpenAI (3072), bge-m3 (1024),
+-- nomic-embed-text (768) and qwen3-embedding:8b (4096) can all coexist. Switching
+-- the active provider is a config change (EMBEDDING_PROVIDER), and the same query
+-- can be embedded by each provider and searched against its own vectors to
+-- compare retrieval quality side by side.
+--
+-- No ANN (hnsw/ivfflat) index is created on purpose: pgvector 0.8 caps those at
+-- 2000 dims for `vector` (4000 for `halfvec`), so 3072 and 4096 cannot be
+-- indexed at all, and the conversation corpus is small enough that an exact
+-- cosine scan is fast. Add a halfvec index later if the corpus grows past that.
+
+CREATE TABLE IF NOT EXISTS conversation_embeddings (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    provider        TEXT NOT NULL,
+    model           TEXT NOT NULL,
+    dim             INTEGER NOT NULL,
+    vec_768         vector(768),
+    vec_1024        vector(1024),
+    vec_3072        vector(3072),
+    vec_4096        vector(4096),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (conversation_id, provider, model),
+    -- Exactly one dimension-bucket column must be populated, and it must match dim.
+    CONSTRAINT conversation_embeddings_one_vec CHECK (
+        (vec_768 IS NOT NULL)::int
+      + (vec_1024 IS NOT NULL)::int
+      + (vec_3072 IS NOT NULL)::int
+      + (vec_4096 IS NOT NULL)::int = 1
+    ),
+    CONSTRAINT conversation_embeddings_dim_match CHECK (
+        (dim = 768  AND vec_768  IS NOT NULL) OR
+        (dim = 1024 AND vec_1024 IS NOT NULL) OR
+        (dim = 3072 AND vec_3072 IS NOT NULL) OR
+        (dim = 4096 AND vec_4096 IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_embeddings_conversation
+    ON conversation_embeddings (conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_embeddings_provider_model
+    ON conversation_embeddings (provider, model);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,11 +229,12 @@ def stub_ollama_requests(monkeypatch, test_settings: Settings):
 
     monkeypatch.setattr(EmbeddingClient, "_request", fake_request, raising=False)
 
-    # Ensure shared client uses the same behaviour
-    async def fake_embed(text: str):
+    # Ensure shared client uses the same behaviour. Signatures mirror
+    # EmbeddingClient.embed/embed_batch, which accept provider/model overrides.
+    async def fake_embed(text: str, provider: str | None = None, model: str | None = None):
         return [0.1] * test_settings.EMBEDDING_DIMENSIONS
 
-    async def fake_embed_batch(texts):
+    async def fake_embed_batch(texts, provider: str | None = None, model: str | None = None):
         return [[0.1] * test_settings.EMBEDDING_DIMENSIONS for _ in texts]
 
     monkeypatch.setattr(ollama_client, "embed", fake_embed, raising=False)

--- a/tests/unit/test_embedding_provider.py
+++ b/tests/unit/test_embedding_provider.py
@@ -1,0 +1,103 @@
+"""Unit tests for config-driven embedding provider selection."""
+
+import pytest
+
+from app.crud.embeddings import column_for_dim
+from app.ollama_client import EmbeddingClient
+
+
+@pytest.mark.unit
+def test_column_for_dim_maps_known_dimensions():
+    assert column_for_dim(768) == "vec_768"
+    assert column_for_dim(1024) == "vec_1024"
+    assert column_for_dim(3072) == "vec_3072"
+    assert column_for_dim(4096) == "vec_4096"
+
+
+@pytest.mark.unit
+def test_column_for_dim_rejects_unknown_dimension():
+    with pytest.raises(ValueError, match="Unsupported embedding dimension"):
+        column_for_dim(512)
+
+
+def _client(provider: str) -> EmbeddingClient:
+    return EmbeddingClient(
+        provider=provider,
+        openai_api_key="sk-test",
+        openai_model="text-embedding-3-large",
+        ollama_url="http://ollama:11434",
+        ollama_model="bge-m3",
+    )
+
+
+@pytest.mark.unit
+def test_active_provider_and_model_follow_config():
+    ollama = _client("ollama")
+    assert ollama.active_provider == "ollama"
+    assert ollama.active_model == "bge-m3"
+
+    openai = _client("openai")
+    assert openai.active_provider == "openai"
+    assert openai.active_model == "text-embedding-3-large"
+
+
+@pytest.mark.unit
+def test_provider_selection_is_case_insensitive():
+    assert _client("OpenAI").active_provider == "openai"
+
+
+@pytest.mark.unit
+def test_resolve_overrides_provider_and_model():
+    client = _client("ollama")
+    assert client._resolve(None, None) == ("ollama", "bge-m3")
+    assert client._resolve("openai", None) == ("openai", "text-embedding-3-large")
+    assert client._resolve("ollama", "qwen3-embedding:8b") == (
+        "ollama",
+        "qwen3-embedding:8b",
+    )
+
+
+@pytest.mark.unit
+async def test_embed_routes_to_selected_provider(monkeypatch):
+    client = _client("ollama")
+    calls = {}
+
+    async def fake_ollama(text, model):
+        calls["ollama"] = (text, model)
+        return [0.0] * 1024
+
+    async def fake_openai(texts, model):
+        calls["openai"] = (texts, model)
+        return [[0.0] * 3072]
+
+    monkeypatch.setattr(client, "_ollama_embed", fake_ollama)
+    monkeypatch.setattr(client, "_openai_embed", fake_openai)
+
+    # Active provider (ollama)
+    vec = await client.embed("hello")
+    assert len(vec) == 1024
+    assert calls["ollama"] == ("hello", "bge-m3")
+
+    # Override to openai for comparison
+    vec = await client.embed("hello", provider="openai")
+    assert len(vec) == 3072
+    assert calls["openai"] == (["hello"], "text-embedding-3-large")
+
+
+@pytest.mark.unit
+async def test_embed_raises_on_unknown_provider():
+    client = _client("ollama")
+    with pytest.raises(ValueError, match="Unknown embedding provider"):
+        await client.embed("hello", provider="bogus")
+
+
+@pytest.mark.unit
+async def test_openai_without_key_raises():
+    client = EmbeddingClient(
+        provider="openai",
+        openai_api_key="",
+        ollama_url="http://ollama:11434",
+        ollama_model="bge-m3",
+    )
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY is not set"):
+        await client.embed("hello")


### PR DESCRIPTION
## What

Make the embedding provider explicit and config-driven so providers can be switched and compared, store per-provider vectors so they coexist, and harden the ingest path against real Claude Code transcripts.

## Why

The embedder implicitly picked OpenAI-if-key-else-Ollama with a silent fallback, and stored a single fixed-dimension vector per conversation — so you couldn't hold (or compare) embeddings from multiple providers/models. Vectors from different models have different dimensions and aren't comparable.

## Changes

- **`EMBEDDING_PROVIDER`** (`ollama`|`openai`) — explicit selection, no implicit fallback, no silent switch (raises on failure / missing key).
- **`conversation_embeddings`** table: one row per `(conversation, provider, model)`, vector stored in a dimension-bucket column (`vec_768/1024/3072/4096`) so OpenAI (3072), bge-m3 (1024), qwen3-embedding:8b (4096), nomic (768) coexist. No ANN index (pgvector 0.8 caps hnsw at 2000 dims / 4000 halfvec; corpus is small enough for exact cosine scan).
- **Store** writes to `conversation_embeddings` keyed by active provider/model (legacy `conversations.embedding` left unused).
- **Search** embeds the query with the requested/active provider and scans that provider/model's vectors. `SearchQuery` gains `provider`/`model` for side-by-side comparison.
- **`POST /conversations/reembed`** — backfill another provider over the same corpus.
- **Ingest robustness**: `EMBEDDING_MAX_CHARS` head-clip + halve-and-retry on context-length overflow (long/dense transcripts exceed bge-m3's 8192-token window); supply `id` via `gen_random_uuid()` in the raw upsert (table id default is Python-side).

## Verification

- Unit tests for provider resolution + dim→column mapping.
- Updated the Ollama test stub to the new `embed(text, provider, model)` signature.
- Integration `test_conversations` (store→search) green.
- **End-to-end: ingested 204 real Claude Code main sessions (0 failures) against the self-hosted k3s Ollama (bge-m3); semantic search returns relevant conversations.**

## Note

`supabase/migrations/` does not cleanly fresh-init on plain pgvector (two competing schema lineages + Supabase `auth` deps + >2000-dim ANN indexes). The real schema SoT is the SQLAlchemy models (tests build via `Base.metadata.create_all`). Consolidating the migrations into a single models-derived baseline is a recommended follow-up so the stack fresh-inits without manual `create_all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)