### PR TITLE
chore(funding): drop personal funding section + fix clone URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ airis api-shell       # Enter container, then run commands inside
 
 **MindBase** is the memory substrate of the AIRIS ecosystem - a local-first AI conversation knowledge management system with semantic search via PostgreSQL + pgvector + Ollama.
 
-**Key Integration**: Part of [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) which provides unified MCP access. MindBase exposes `mindbase_search` and `mindbase_store` tools.
+**Key Integration**: Part of [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) which provides unified MCP access. MindBase exposes `conversation_save`, `conversation_hybrid_search`, and `memory_search` tools.
 
 **Stack**: Hybrid Python/TypeScript pnpm monorepo
 - **Storage**: PostgreSQL 17 + pgvector
-- **Embeddings**: OpenAI text-embedding-3-large (3072-dim, primary) → Ollama qwen3-embedding:8b (1024-dim, fallback)
+- **Embeddings**: Config-driven dual-provider — Ollama (default, `EMBEDDING_PROVIDER=ollama`) or OpenAI; default model `bge-m3` (1024-dim). Set `EMBEDDING_PROVIDER=openai` for OpenAI `text-embedding-3-large` (3072-dim)
 - **API**: FastAPI (Python)
 - **MCP Server**: TypeScript (stdio transport)
 
@@ -102,7 +102,9 @@ apps/
 
 libs/
 ├── collectors/       # Python conversation collectors (Claude, Cursor, ChatGPT, etc.)
+├── embedding/        # TypeScript embedding client
 ├── generators/       # TypeScript article generators (Qiita, Zenn, Note publishing)
+├── markdown/         # TypeScript markdown utilities
 ├── processors/       # TypeScript content processors
 └── shared/           # Shared TypeScript types
 
@@ -138,11 +140,13 @@ tests/                # pytest tests (unit/integration/e2e markers)
 
 ### Embedding Strategy (Dual Provider)
 
-- **Primary**: OpenAI `text-embedding-3-large` (3072-dim) — requires `OPENAI_API_KEY`
-- **Fallback**: Ollama `qwen3-embedding:8b` (1024-dim) — local, free
-- Both Python (`ollama_client.py`) and TypeScript (`storage/postgres.ts`) implement the same fallback logic
-- Dimensions auto-detected; override with `EMBEDDING_DIMENSIONS`
-- Index: ivfflat for pgvector similarity search
+- **Config-driven**: `EMBEDDING_PROVIDER=ollama` (default) or `EMBEDDING_PROVIDER=openai` — no implicit key-presence fallback; a misconfigured provider raises immediately
+- **Ollama** (default): model set by `EMBEDDING_MODEL` (`.env.example` default: `bge-m3`, 1024-dim)
+- **OpenAI**: `text-embedding-3-large` (3072-dim) — requires `OPENAI_API_KEY`
+- Per-provider vectors coexist in `conversation_embeddings` table; switching provider does not destroy existing vectors. Use `POST /conversations/reembed` to backfill
+- Dimensions auto-detected from model name; override with `EMBEDDING_DIMENSIONS`
+- Both Python (`apps/api/ollama_client.py`) and TypeScript (`storage/postgres.ts`) use `EMBEDDING_PROVIDER` config
+- pgvector index: **no ANN index** on `conversation_embeddings` (pgvector 0.8 caps ivfflat/hnsw at 2000 dims for `vector`; exact cosine scan is used instead)
 
 ### Data Pipeline (Raw → Derived)
 
@@ -174,8 +178,7 @@ Tuning via env vars: `SEARCH_RECENCY_TAU_SECONDS` (14d default), `SEARCH_RECENCY
 
 ### CI/CD
 
-- Push to `next` or PR to `main` で CI 実行 (pnpm install → test → build)
-- `next` → `main` はCI成功時に自動マージ
+- Push to `main` or PR to `main` で CI 実行 (pnpm install → test → build)
 - ワークフロー: `.github/workflows/ci.yml` (auto-generated from manifest.toml)
 
 ## Development Conventions

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Because AIRIS only loads tool instructions when the model actually chooses MindB
 
 ```bash
 # 1. Clone (adjust the destination if needed)
-git clone https://github.com/kazukinakai/mindbase.git ~/github/mindbase
+git clone https://github.com/agiletec-inc/mindbase.git ~/github/mindbase
 cd ~/github/mindbase
 
 # 2. Copy environment defaults
@@ -256,17 +256,6 @@ Explore other tools in the AIRIS ecosystem:
 - **[cmd-ime](https://github.com/agiletec-inc/cmd-ime)** - macOS IME switcher (Cmd key toggle)
 - **[neural](https://github.com/agiletec-inc/neural)** - Local LLM translation tool (DeepL alternative)
 - **[airiscode](https://github.com/agiletec-inc/airiscode)** - Terminal-first autonomous coding agent
-
----
-
-## 💖 Support This Project
-
-If you find MindBase helpful, consider supporting its development:
-
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?style=for-the-badge&logo=buy-me-a-coffee)](https://buymeacoffee.com/kazukinakad)
-[![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink?style=for-the-badge&logo=github)](https://github.com/sponsors/kazukinakad)
-
-Your support helps maintain and improve all AIRIS projects!
 
 ---
 

--- a/content/articles/2026-03-28-claude-code-senior-engineer-en.md
+++ b/content/articles/2026-03-28-claude-code-senior-engineer-en.md
@@ -1,0 +1,322 @@
+---
+title: "Claude Code Kept Making the Same Mistakes, So I Trained It Into a Senior Engineer"
+description: "After months of loops, hallucinations, and broken environments, I built a 4-layer defense architecture for Claude Code. CLAUDE.md, Hooks, MCP Gateway, and Superpowers plugin — here's the full setup with all the failures along the way."
+author: "Kazuki Nakai"
+date: "2026-03-28"
+tags: ["claude-code", "ai-coding", "mcp", "developer-tools", "productivity"]
+language: "en"
+---
+
+# Claude Code Kept Making the Same Mistakes, So I Trained It Into a Senior Engineer
+
+I've been using Claude Code for two years. The first six months were, honestly, disappointing.
+
+It could write code. But it would run `npm install` on the host and break my Docker environment. It would skip tests and report "Done!" It would fix the same bug three times with the same wrong approach. It would create files I never asked for. It nearly committed `.env` files.
+
+I almost gave up on it.
+
+But the problem wasn't Claude Code. **The problem was me.** I was treating it like a magic box instead of a team member. A junior engineer thrown into a codebase without rules will cause the same chaos. What Claude Code lacked wasn't ability — it was **discipline**.
+
+This article walks through the 4-layer defense architecture that transformed Claude Code from "an unpredictable junior" into "a self-verifying senior engineer." Every configuration shown here is from my actual production setup.
+
+---
+
+## The First Failure: Too Much Freedom
+
+When I first set up Claude Code, my CLAUDE.md had one line: "Respond in Japanese."
+
+The results:
+
+- **Environment destruction**: Ran `npm install` on host → Docker build cache invalidated → 2 hours debugging
+- **Infinite loops**: Fixing a TypeScript error → build → different error → fix → build → back to the original error. Five times.
+- **False completion reports**: "Tests pass!" → Actually ran them → 3 failures → "I couldn't find the test files so I skipped them"
+- **Unsolicited refactoring**: Asked to fix a bug → "improved" surrounding code → introduced a new bug
+
+The worst incident: I asked Claude Code to fix a bug on Friday night and went to sleep. Saturday morning, `node_modules` had been generated on the host, and my entire Docker environment was broken. I spent Saturday morning rebuilding it.
+
+That's when I realized: **Claude Code needs to learn what NOT to do before learning what to do.**
+
+---
+
+## Layer 1: CLAUDE.md — Write the Constitution
+
+CLAUDE.md is Claude Code's constitution. It's loaded at the start of every conversation and governs all behavior.
+
+The core of mine:
+
+```markdown
+## Docker-First
+
+Everything runs inside Docker containers. Never execute package managers
+or runtimes directly on the host.
+
+## Safety
+
+- Never disable or bypass hooks (including --no-verify)
+- Fix the cause of test/lint failures, don't disable the checks
+- Get user confirmation before push/deploy
+- Never modify config files without explicit instruction
+
+## Verify — Confirm Before Reporting
+
+- Don't just say "implemented" — verify with Playwright or browser
+- Run `airis test` before push, confirm zero errors
+- After push, `gh run watch` to wait for CI, fix failures yourself
+- Don't use the user as a debugger
+```
+
+### Why "Docker-First" Comes First
+
+Because it's the most violated rule. Claude Code defaults to running `npm install` on the host because it's "easiest." In a Docker environment, that's catastrophic.
+
+But CLAUDE.md alone wasn't enough. Claude Code "forgets" rules in long conversations. Rules at the edge of the context window lose to new instructions.
+
+That's why I needed Layer 2.
+
+---
+
+## Layer 2: Hooks — Physically Block Dangerous Actions
+
+CLAUDE.md is a request. Hooks are the law.
+
+Claude Code has three hook points:
+
+- **PreToolUse**: Intercept before tool execution
+- **SessionStart**: Run at session start
+- **Stop**: Run at session end
+
+### Docker-First Guard
+
+The single most impactful change:
+
+```bash
+#!/bin/bash
+# PreToolUse hook for Bash tool
+
+COMMAND="$1"
+
+if echo "$COMMAND" | grep -qE '^\s*(pnpm|npm|yarn)\s+(install|add|remove|update)' ||
+   echo "$COMMAND" | grep -qE '^\s*pip\s+install' ||
+   echo "$COMMAND" | grep -qE '^\s*brew\s+install'; then
+  echo "BLOCKED: Host package manager execution detected."
+  echo "Use: docker compose exec <service> <command>"
+  exit 1
+fi
+```
+
+When Claude Code tries `pnpm install` on the host, **the command is blocked before execution**. Claude Code gets: "Blocked. Use `docker compose exec` instead."
+
+Before: Cleaning up host `node_modules` 2-3 times per week.
+After: **Zero.**
+
+### Pre-Push Test Enforcement
+
+```bash
+if ! airis test; then
+  echo "ERROR: Tests failed. Fix before pushing."
+  exit 1
+fi
+```
+
+The "tests pass!" lie? Gone. If they don't pass, the push physically cannot happen.
+
+---
+
+## Layer 3: MCP Gateway — 60+ Tools in One Command
+
+This is where it gets interesting.
+
+MCP (Model Context Protocol) lets you connect external tools to Claude Code. But naively registering 60 tools with their schemas eats **thousands of tokens** from your context window. Every conversation. Whether you use them or not. And managing dozens of server configs becomes its own nightmare.
+
+So I built [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway).
+
+### Setup: 3 Lines
+
+```bash
+git clone https://github.com/agiletec-inc/airis-mcp-gateway.git
+cd airis-mcp-gateway && docker compose up -d
+claude mcp add --scope user --transport sse airis-mcp-gateway http://localhost:9400/sse
+```
+
+That's it. These 3 lines give you documentation lookup (context7), web search (tavily), database operations (supabase), payments (stripe), infrastructure management (cloudflare), browser automation (chrome-devtools), design files (figma) — 60+ tools, ready to use.
+
+### The Core Idea: `airis-exec` — One Tool to Call Them All
+
+Traditional MCP requires registering each tool individually. airis-mcp-gateway flips this: **Claude Code sees only one meta-tool called `airis-exec`**.
+
+```
+Claude Code
+    ↓ "calls airis-exec once"
+airis-mcp-gateway (FastAPI)
+    ↓ routes to the right server internally
+┌─────────────────────────────────┐
+│ context7  tavily  supabase      │
+│ stripe  cloudflare  figma       │
+│ chrome-devtools  memory  ...    │
+│         25+ servers             │
+└─────────────────────────────────┘
+```
+
+The trick: the full list of available tools is **embedded in `airis-exec`'s tool description**. Claude Code reads the description, knows what's available, and calls it directly. **No discovery step needed.**
+
+```
+Claude Code's reasoning:
+"I need to look up Next.js docs"
+→ reads airis-exec description
+→ sees [context7] resolve-library-id, query-docs
+→ airis-exec("context7:resolve-library-id", { "libraryName": "next.js" })
+→ official docs come back
+→ writes code based on actual documentation
+```
+
+One tool call to access official documentation, then write code. **This alone cut hallucinations dramatically.**
+
+### Token Reduction
+
+- Before: 60 tools × ~700 tokens/schema = **42,000 tokens** (always consumed)
+- After: `airis-exec` + 6 supporting meta-tools = **~1,400 tokens**
+
+**97% reduction.** Not an estimate — measured.
+
+Freeing up 40K tokens of context window means longer conversations, bigger refactors, and multi-file changes without hitting limits.
+
+### HOT/COLD Lifecycle
+
+Not every server needs to run all the time. Frequently used ones (context7, tavily) stay HOT. Occasional ones (figma, stripe) go COLD and auto-start on first call.
+
+COLD servers **auto-enable** when called through `airis-exec`. Even disabled servers get discovered, enabled, started, and executed — all in one call. No manual config switching needed.
+
+---
+
+## Layer 4: Superpowers — Force "Think Before You Code"
+
+The final piece.
+
+Claude Code's biggest problem is **writing code before thinking**. Exactly like a human junior engineer. "Let me just get something working" → spaghetti code.
+
+[Superpowers](https://github.com/anthropics/claude-code-plugins/tree/main/superpowers) is a plugin from Claude Code's official plugin marketplace (`/plugins` → search "superpowers"). It **enforces workflows**:
+
+| Skill | Enforced Behavior |
+|-------|-------------------|
+| `brainstorming` | Design before coding. Compare 2-3 approaches |
+| `writing-plans` | Plan before implementing. Specify files, changes, verification |
+| `test-driven-development` | Write tests first. Then implement |
+| `systematic-debugging` | Don't shotgun-fix. Hypothesize, verify, then fix |
+| `verification-before-completion` | Before saying "done," actually run the tests |
+
+### Before/After
+
+**Before (no Superpowers)**:
+```
+Me: Fix this bug
+Claude: [immediately edits code] → [build error] → [different fix] → [test fails] → [another fix] → 5 loops
+```
+
+**After (with Superpowers)**:
+```
+Me: Fix this bug
+Claude: [systematic-debugging activates]
+  1. Confirm reproduction steps
+  2. Form 3 hypotheses
+  3. Test most likely hypothesis
+  4. Identify root cause
+  5. Write test first
+  6. Fix
+  7. Verify tests pass
+  8. Visual check in browser
+```
+
+Loop count dropped by **~70%**.
+
+---
+
+## The 4 Layers Working Together
+
+Each layer is useful on its own, but the real power is the combination:
+
+```
+Layer 4: Superpowers  → Think before coding (workflow enforcement)
+Layer 3: MCP Gateway  → Use correct information (official docs)
+Layer 2: Hooks        → Physically prevent dangerous actions (guardrails)
+Layer 1: CLAUDE.md    → Share rules and values (constitution)
+```
+
+Lower layers are "hard" constraints. Upper layers are "soft" constraints.
+
+CLAUDE.md alone is just a polite request. Hooks stop dangerous actions but don't ensure correctness. Correct information without structure produces spaghetti. You need all four.
+
+**All 4 layers together is what makes Claude Code behave like a senior engineer.**
+
+---
+
+## Getting Started
+
+You don't need everything at once. Here's the order I'd recommend:
+
+### Step 1: Write CLAUDE.md (30 minutes)
+
+Start with your project's basic rules:
+- Language preferences
+- What NOT to do (environment-specific dangers)
+- Definition of "done" (tests required, etc.)
+
+### Step 2: Set Up Hooks (1 hour)
+
+Highest ROI. Add PreToolUse hooks in `settings.json` to block dangerous commands.
+
+### Step 3: Add MCP Gateway (half day)
+
+Docker Compose up, connect via SSE. Start with just context7 (documentation lookup) — it's immediately valuable.
+
+### Step 4: Install Superpowers (5 minutes)
+
+In Claude Code, run `/plugins` → search "superpowers" → install. Immediate effect.
+
+---
+
+## Conclusion
+
+Claude Code is a completely different tool depending on how you configure it.
+
+Out of the box, it's a "capable but undisciplined junior engineer." With CLAUDE.md sharing values, Hooks physically preventing mistakes, MCP Gateway providing accurate information, and Superpowers enforcing structured thinking — it becomes something else entirely.
+
+Since building this setup, I've been developing products at 5x my previous speed as a solo founder. Claude Code isn't a "tool." Trained properly, it's a teammate.
+
+Every configuration shown in this article is running in my actual production environment. If you have questions, drop them in the comments.
+
+---
+
+## Try It Now
+
+You don't need to build this setup from scratch. It's all open source.
+
+### airis-mcp-gateway — 60+ AI Tools in One Command
+
+```bash
+git clone https://github.com/agiletec-inc/airis-mcp-gateway.git
+cd airis-mcp-gateway && docker compose up -d
+claude mcp add --scope user --transport sse airis-mcp-gateway http://localhost:9400/sse
+```
+
+Documentation lookup, web search, database operations, payments, infrastructure, browser automation — all through a single connection.
+
+**GitHub**: [agiletec-inc/airis-mcp-gateway](https://github.com/agiletec-inc/airis-mcp-gateway)
+
+### airis-monorepo — Auto-Generate Docker-First Dev Environments
+
+Write a `manifest.toml`, and it generates your Dockerfile, docker-compose.yml, and CI/CD pipeline automatically. Same environment on every machine, every time. This is the CLI tool that makes the Docker-First philosophy from this article practical.
+
+**GitHub**: [agiletec-inc/airis-monorepo](https://github.com/agiletec-inc/airis-monorepo)
+
+---
+
+### What's Next
+
+This article covered the 4-layer overview. Detailed deep-dives on each layer are coming:
+
+- **CLAUDE.md Design Patterns** — Rules that actually worked and why
+- **airis-mcp-gateway Complete Guide** — From install to custom server integration
+- **Hooks Cookbook** — Practical PreToolUse / SessionStart / Stop recipes
+- **Superpowers in Practice** — Automating TDD, debugging, and planning workflows
+
+Let me know in the comments which topic you want first.

--- a/content/articles/2026-03-28-claude-code-senior-engineer-ja.md
+++ b/content/articles/2026-03-28-claude-code-senior-engineer-ja.md
@@ -1,0 +1,345 @@
+---
+title: "Claude Codeが同じミスを繰り返すので、シニアエンジニアに育て直した話"
+description: "Claude Codeのループ、幻覚、環境破壊に悩まされた末に辿り着いた、4層の防御アーキテクチャ。CLAUDE.md、Hooks、MCP Gateway、Superpowersプラグインを組み合わせた実践的な設定方法を、失敗談とともに全公開する。"
+author: "Kazuki Nakai"
+date: "2026-03-28"
+tags: ["claude-code", "ai-coding", "mcp", "developer-tools", "productivity"]
+language: "ja"
+---
+
+# Claude Codeが同じミスを繰り返すので、シニアエンジニアに育て直した話
+
+Claude Codeを使い始めて2年になる。最初の半年は正直、期待はずれだった。
+
+コードは書いてくれる。でも `pnpm install` をホストで実行してDocker環境を壊す。テストを通さずに「完了しました」と報告してくる。同じバグを3回直して3回とも同じ方法で失敗する。指示していないファイルを勝手に作る。`.env` をコミットしそうになる。
+
+「AIってこんなもんか」と思いかけた。
+
+でも違った。Claude Codeが悪いんじゃない。**俺の使い方が悪かった**。人間のジュニアエンジニアだって、ルールを教えずに放り込んだら同じことをする。Claude Codeに足りなかったのは、能力じゃなくて**規律**だった。
+
+この記事では、Claude Codeを「言われたことをなんとなくやるジュニア」から「自分で考えて検証するシニアエンジニア」に変えた、4層の防御アーキテクチャを全部公開する。
+
+---
+
+## 最初の失敗: 「自由にやらせすぎた」
+
+Claude Codeを導入した当初、CLAUDE.mdには「日本語で回答して」くらいしか書いていなかった。
+
+結果:
+
+- **環境破壊**: `npm install` をホストで実行 → Docker環境との不整合でビルドが壊れる → 原因調査に2時間
+- **無限ループ**: TypeScriptの型エラーを直そうとして、修正→ビルド→別のエラー→修正→ビルド→最初のエラーに戻る、を5回繰り返す
+- **嘘の完了報告**: 「テストが通りました」→ 実際に走らせてみると3件失敗 → 聞くと「テストファイルが見つからなかったのでスキップしました」
+- **勝手な改善**: バグ修正を頼んだら、周辺のコードも「ついでにリファクタ」して別のバグを埋め込む
+
+一番痛かったのは、金曜の夜にClaude Codeに「このバグ直して」と頼んで寝て、朝起きたら `node_modules` がホストに生成されていて、Docker環境が完全に壊れていたことだ。土曜の午前中を環境の復旧に費やした。
+
+ここで気づいた。**Claude Codeには「やるべきこと」じゃなくて「やってはいけないこと」を先に教える必要がある。**
+
+---
+
+## 第1層: CLAUDE.md — 憲法を書く
+
+CLAUDE.mdはClaude Codeの「憲法」だ。全ての会話で最初に読み込まれ、全ての行動の基準になる。
+
+俺のCLAUDE.mdのコア部分はこうなっている:
+
+```markdown
+# Global Rules
+
+日本語で回答する。コードコメントは英語。
+
+## Docker-First
+
+全てDockerコンテナ内で実行する。ホストでパッケージマネージャやランタイムを直接実行しない。
+
+## Safety
+
+- hookの無効化・削除・迂回をしない（`--no-verify`, `git config core.hooksPath` 変更を含む）
+- テスト/lintの失敗はチェックの無効化ではなく原因を修正する
+- push/deploy前にユーザーの確認を取る
+- 設定ファイルはユーザーの明示的な指示なしに変更しない
+
+## Verify — 完了報告の前に自分で確認する
+
+- 「実装しました」で終わりにせず、Playwrightまたはブラウザで自分の目で動作確認する
+- push前に `airis test` を実行してエラー0を確認する
+- push後は `gh run watch` でCI完了を待ち、失敗したら自分で修正・re-pushする
+- ユーザーをデバッガー代わりにしない
+```
+
+### なぜ「Docker-First」を最初に書くのか
+
+これが一番重要なルールだからだ。Claude Codeはデフォルトで `npm install` や `pip install` をホストで実行しようとする。それが「一番簡単」だから。でもDocker環境では、それが致命的な環境破壊になる。
+
+CLAUDE.mdだけでは不十分だった。Claude Codeは長い会話の中でルールを「忘れる」。コンテキストウィンドウの端に追いやられたルールは、新しい指示に負ける。
+
+だから第2層が必要になった。
+
+---
+
+## 第2層: Hooks — 物理的に止める
+
+CLAUDE.mdは「お願い」だ。Hooksは「法律」だ。
+
+Claude Codeには3つのフックポイントがある:
+
+- **PreToolUse**: ツール実行前に割り込む
+- **SessionStart**: セッション開始時に実行
+- **Stop**: セッション終了時に実行
+
+### Docker-First Guard
+
+一番効果があったのがこれだ:
+
+```bash
+#!/bin/bash
+# PreToolUse hook for Bash tool
+# Block host-level package manager commands
+
+COMMAND="$1"
+
+# Blocked patterns
+if echo "$COMMAND" | grep -qE '^\s*(pnpm|npm|yarn)\s+(install|add|remove|update)' ||
+   echo "$COMMAND" | grep -qE '^\s*pip\s+install' ||
+   echo "$COMMAND" | grep -qE '^\s*brew\s+install'; then
+  echo "BLOCKED: Host package manager execution detected."
+  echo "Use: docker compose exec <service> <command>"
+  exit 1
+fi
+```
+
+これで `pnpm install` をホストで実行しようとすると、**コマンドが実行される前にブロックされる**。Claude Codeには「ブロックされたよ。`docker compose exec` を使って」というメッセージが返る。
+
+導入前: 週に2〜3回、ホストの `node_modules` を消す作業が発生
+導入後: **ゼロ**
+
+### Pre-Push テスト強制
+
+もう一つ、地味だけど効果絶大だったのがpush前のテスト強制:
+
+```bash
+# Pre-push hook
+# Blocks push if tests fail
+
+if ! airis test; then
+  echo "ERROR: Tests failed. Fix before pushing."
+  exit 1
+fi
+```
+
+Claude Codeが「テスト通りました」と嘘をつく問題は、これで完全に消えた。通ってなかったらそもそもpushできないから。
+
+### Session Start: コンテキスト注入
+
+セッション開始時に、プロジェクトの種類とスタックを自動検出して表示する:
+
+```
+Project: node | Stack: [supabase, docker, env, github-actions]
+Tip: Use airis-route for optimal tool selection
+```
+
+これで毎回「このプロジェクトはDockerで動いてて…」と説明する手間が省ける。
+
+---
+
+## 第3層: MCP Gateway — 1コマンドで60以上のツールを手に入れる
+
+ここからが本題だ。
+
+Claude Codeに外部ツールを接続するMCP（Model Context Protocol）は強力だが、素朴に使うと**トークンを大量に消費する**。60個のツールをそれぞれスキーマ付きで登録すると、それだけでコンテキストウィンドウの数千トークンを食う。しかもツールが増えるたびに設定が膨らんで管理が地獄になる。
+
+そこで作ったのが [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway) だ。
+
+### セットアップは3行
+
+```bash
+git clone https://github.com/agiletec-inc/airis-mcp-gateway.git
+cd airis-mcp-gateway && docker compose up -d
+claude mcp add --scope user --transport sse airis-mcp-gateway http://localhost:9400/sse
+```
+
+これだけ。この3行で、ドキュメント検索（context7）、Web検索（tavily）、データベース操作（supabase）、決済（stripe）、インフラ管理（cloudflare）、デザインファイル（figma）、ブラウザ操作（chrome-devtools）— 60以上のツールが一発で使えるようになる。
+
+### 核心: `airis-exec` — たった1つのツールで全部呼べる
+
+従来のMCPでは、60個のツールを個別に登録する必要があった。airis-mcp-gatewayの発想は逆だ。**Claude Codeに見せるのは `airis-exec` という1つのメタツールだけ**。
+
+```
+Claude Code
+    ↓ "airis-exec を1回呼ぶだけ"
+airis-mcp-gateway (FastAPI)
+    ↓ 内部で適切なサーバーにルーティング
+┌─────────────────────────────────┐
+│ context7  tavily  supabase      │
+│ stripe  cloudflare  figma       │
+│ chrome-devtools  memory  ...    │
+│         25+ servers             │
+└─────────────────────────────────┘
+```
+
+`airis-exec` のツール説明文の中に、利用可能な全ツールのリストが埋め込まれている。Claude Codeはこの説明文を読むだけで「何が使えるか」を把握し、そのまま呼び出せる。**ツール検索のステップすら不要**。
+
+```
+Claude Codeの思考:
+「Next.jsのドキュメントを調べたい」
+→ airis-execの説明文を見る
+→ [context7] resolve-library-id, query-docs がある
+→ airis-exec("context7:resolve-library-id", { "libraryName": "next.js" })
+→ 公式ドキュメントが返ってくる
+→ それを元にコードを書く
+```
+
+1回のツール呼び出しで、公式ドキュメントにアクセスしてからコードを書く。**これだけで幻覚が激減する**。
+
+### トークン削減効果
+
+- Before: 60ツール × 平均700トークン/スキーマ = **42,000トークン**（常時消費）
+- After: `airis-exec` 含む7メタツール = **約1,400トークン**
+
+**97%削減**。これは誇張じゃない。実測値だ。
+
+コンテキストウィンドウの4万トークンが空くということは、その分だけ長い会話ができる。大規模なリファクタリングや、複数ファイルにまたがる作業で違いが出る。
+
+### HOT/COLD ライフサイクル
+
+全サーバーを常時起動しておく必要はない。よく使うもの（context7, tavily）はHOT（常時起動）、たまに使うもの（figma, stripe）はCOLD（オンデマンド起動）にする。
+
+COLDサーバーは `airis-exec` で初めて呼ばれた時に**自動起動**する。無効化されたサーバーすら、`airis-exec` で呼べば自動的に有効化→起動→実行まで走る。使い終わったらスリープ。設定を手動で切り替える必要はない。
+
+---
+
+## 第4層: Superpowers — 「考えてから書く」を強制する
+
+最後のピースが[Superpowers](https://github.com/anthropics/claude-code-plugins/tree/main/superpowers)プラグインだ。Claude Codeの公式プラグインマーケットプレイスからインストールできる（`/plugins` → `superpowers` で検索）。
+
+Claude Codeの最大の問題は、**考える前にコードを書き始める**ことだ。人間のジュニアエンジニアと全く同じ。「まず動くものを」と手を動かして、設計を考えずにスパゲッティを量産する。
+
+Superpowersは、Claude Codeに**ワークフローを強制する**プラグインだ:
+
+### 主要スキル
+
+| スキル | 強制する行動 |
+|--------|-------------|
+| `brainstorming` | コードを書く前に設計を考える。2〜3のアプローチを比較する |
+| `writing-plans` | 実装前に計画を立てる。変更ファイル、変更内容、検証手順を明記する |
+| `test-driven-development` | テストを先に書く。実装はその後 |
+| `systematic-debugging` | バグを見たら闇雲に直さず、仮説を立てて検証する |
+| `verification-before-completion` | 「完了しました」と言う前に、自分でテストを走らせて確認する |
+
+### Before/After
+
+**Before（Superpowersなし）**:
+```
+俺: このバグ直して
+Claude: [即座にコードを修正] → [ビルドエラー] → [別の修正] → [テスト失敗] → [また修正] → ループ5回
+```
+
+**After（Superpowersあり）**:
+```
+俺: このバグ直して
+Claude: [systematic-debugging発動]
+  1. 再現手順を確認
+  2. 仮説を3つ立てる
+  3. 最も可能性の高い仮説を検証
+  4. 原因特定
+  5. テストを先に書く
+  6. 修正
+  7. テスト通過を確認
+  8. ブラウザで動作確認
+```
+
+ループ回数が体感で**70%減った**。
+
+---
+
+## 4層の相乗効果
+
+この4層は独立して機能するが、組み合わせると相乗効果がある:
+
+```
+Layer 4: Superpowers  → 考えてから書く（ワークフロー強制）
+Layer 3: MCP Gateway  → 正しい情報を使う（公式ドキュメント参照）
+Layer 2: Hooks        → 危険な行動を物理的に止める（ガードレール）
+Layer 1: CLAUDE.md    → 基本ルールと価値観を共有する（憲法）
+```
+
+下の層ほど「ハード」な制約で、上の層ほど「ソフト」な制約。
+
+CLAUDE.mdだけでは「お願い」で終わる。Hooksで物理的に止めても、正しい情報がなければ間違ったコードを書く。正しい情報があっても、考えずに書いたらスパゲッティになる。
+
+**4層全部揃って初めて、Claude Codeはシニアエンジニアのように動く。**
+
+---
+
+## 導入の順番
+
+全部一気に入れる必要はない。俺が辿った順番で入れるのがおすすめだ:
+
+### Step 1: CLAUDE.md を書く（30分）
+
+まずはプロジェクトの基本ルールを書く。最低限:
+- 使用言語
+- やってはいけないこと（環境に依存するもの）
+- 完了の定義（テスト必須、等）
+
+### Step 2: Hooks を設定する（1時間）
+
+一番効果が高い。`settings.json` に PreToolUse フックを追加して、危険なコマンドをブロックする。
+
+### Step 3: MCP Gateway を導入する（半日）
+
+Docker Composeで立ち上げてSSEで接続するだけ。最初はcontext7（ドキュメント参照）だけでも十分。
+
+### Step 4: Superpowers を入れる（5分）
+
+Claude Codeで `/plugins` → `superpowers` を検索してインストールするだけ。すぐに効果が出る。
+
+---
+
+## まとめ
+
+Claude Codeは、設定次第で全く別物になる。
+
+デフォルトのClaude Codeは「能力は高いが規律がないジュニアエンジニア」だ。CLAUDE.mdで価値観を共有し、Hooksで危険な行動を物理的に止め、MCP Gatewayで正しい情報にアクセスさせ、Superpowersで「考えてから書く」を強制する。
+
+この4層を入れてから、俺は一人法人でありながら、以前の5倍のスピードでプロダクトを開発できるようになった。Claude Codeは「ツール」じゃない。正しく育てれば「チームメイト」になる。
+
+この記事で紹介した設定は全て実際に本番環境で使っているものだ。質問があればコメントで聞いてほしい。
+
+---
+
+## 今すぐ試す
+
+この4層の設定環境を自分でゼロから構築する必要はない。OSSとして公開しているので、すぐに使える。
+
+### airis-mcp-gateway — 60以上のAIツールを1コマンドで
+
+```bash
+git clone https://github.com/agiletec-inc/airis-mcp-gateway.git
+cd airis-mcp-gateway && docker compose up -d
+claude mcp add --scope user --transport sse airis-mcp-gateway http://localhost:9400/sse
+```
+
+ドキュメント検索、Web検索、データベース操作、決済、インフラ管理、ブラウザ操作 — 全部これ1つで。
+
+**GitHub**: [agiletec-inc/airis-mcp-gateway](https://github.com/agiletec-inc/airis-mcp-gateway)
+
+### airis-monorepo — Docker-First開発環境を自動生成
+
+`manifest.toml` に設定を書くだけで、Dockerfile、docker-compose.yml、CI/CDパイプラインを自動生成する。どのマシンでも同じ環境が再現できる。この記事で紹介したDocker-Firstの思想を実現するためのCLIツール。
+
+**GitHub**: [agiletec-inc/airis-monorepo](https://github.com/agiletec-inc/airis-monorepo)
+
+---
+
+### 次回予告
+
+この記事では4層の全体像を紹介した。次回以降、各層を深掘りする記事を個別に公開する予定だ:
+
+- **CLAUDE.md 設計パターン集** — 実際に効果があったルールとその理由
+- **airis-mcp-gateway 完全ガイド** — インストールからカスタムサーバー追加まで
+- **Hooks実践レシピ** — PreToolUse / SessionStart / Stop の具体的な設定例
+- **Superpowers活用術** — TDD、デバッグ、プランニングの自動化
+
+気になるテーマがあればコメントで教えてほしい。優先的に書く。

--- a/docs/superpowers/specs/2026-03-28-content-pipeline-design.md
+++ b/docs/superpowers/specs/2026-03-28-content-pipeline-design.md
@@ -1,0 +1,223 @@
+# MindBase Content Pipeline Design
+
+## Context
+
+MindBase has 2 years of AI conversation data (Claude Code, ChatGPT, Cursor, etc.) sitting in its database. The goal is to turn this into a branding engine: automatically generate high-quality blog articles from conversation data and publish them across multiple platforms in multiple languages, driving visibility and customer acquisition for agiletec.
+
+The first content theme is "Claude Code mastery" — tips for reducing loops/mistakes, MCP Gateway, Superpowers plugin, Playwright CLI, Hooks/Rules/CLAUDE.md configuration. Articles follow a failure-first storytelling format: what was tried, what failed, what finally worked.
+
+## Architecture Overview
+
+```
+Daily cron
+  |
+  v
+Scanner (conversation analysis, topic extraction, scoring)
+  |
+  v
+Generator (article drafts in JA + EN via LLM)
+  |
+  v
+LLM Reviewer (quality, fact-check, tone, kazuki-voice)
+  |
+  +-- pass --> Publisher (auto-publish to all platforms)
+  |                |
+  |                v
+  |            Slack (daily completion report with links)
+  |
+  +-- fail --> Slack ("this one needs human review")
+```
+
+### Phases
+
+- **Startup**: LLM review -> all articles sent to Slack for kazuki to skim -> approve
+- **Stable**: LLM review pass -> auto-publish. Only failures go to Slack for human review
+
+### Backfill
+
+Initial run processes 2 years of conversation history to build a large article idea backlog. Daily cron then processes new conversations as delta.
+
+## Modules
+
+| Module | Responsibility | Location |
+|--------|---------------|----------|
+| **scanner** | Analyze conversations, extract article ideas, score them | `apps/pipeline` |
+| **generator** | idea -> outline -> JA/EN draft via LLM | `apps/pipeline` |
+| **reviewer** | LLM quality gate (quality, fact-check, tone, voice) | `apps/pipeline` |
+| **publisher** | Orchestrate publishing to all platforms | `apps/pipeline` |
+| **slack** | Notifications, approval management | `apps/pipeline` |
+| **adapters** | Platform-specific API abstraction | `libs/adapters` |
+
+## Pipeline Detail
+
+### Scanner
+
+1. Fetch recent conversations from MindBase DB (or full history for backfill)
+2. Semantic analysis to extract topics and potential article angles
+3. Score each idea:
+   - Novelty (dedup against past articles)
+   - Technical depth
+   - Story potential (failure -> resolution arc)
+4. Select top candidates, save to `article_ideas` table
+
+### Generator
+
+1. Take selected idea, generate article outline
+2. Generate Japanese article body (failure-first storytelling, includes code/config examples)
+3. Generate English version (not translation -- rewrite for English audience, adjust cultural context)
+4. Save drafts to `article_drafts` table with status `pending`
+
+### LLM Reviewer
+
+1. Quality check (coherence, readability, value to reader)
+2. Fact check (code examples actually work, config is accurate)
+3. Tone check (matches kazuki's voice, not generic AI tone)
+4. Pass/fail decision with comments
+5. Update draft status to `approved` or `needs_review`
+
+### Publisher
+
+1. Publish to corporate site first (canonical source)
+2. Publish to each platform with canonical URL pointing to corporate
+3. Record all URLs in `article_publications` table
+4. Send Slack completion report
+
+## Data Model
+
+```sql
+-- Article ideas (scanner output)
+article_ideas (
+  id UUID PK,
+  conversation_ids UUID[],        -- source conversations
+  topic TEXT,
+  angle TEXT,                     -- e.g. 'failure-story', 'tips', 'deep-dive'
+  score FLOAT,
+  status TEXT CHECK (status IN ('candidate', 'selected', 'used', 'rejected')),
+  created_at TIMESTAMPTZ
+)
+
+-- Article drafts (generator output)
+article_drafts (
+  id UUID PK,
+  idea_id UUID FK -> article_ideas,
+  language TEXT CHECK (language IN ('ja', 'en')),
+  title TEXT,
+  body TEXT,                      -- Markdown
+  review_status TEXT CHECK (review_status IN ('pending', 'approved', 'rejected', 'needs_review')),
+  review_comment TEXT,
+  created_at TIMESTAMPTZ
+)
+
+-- Publication records (publisher output)
+article_publications (
+  id UUID PK,
+  draft_id UUID FK -> article_drafts,
+  platform TEXT,                  -- 'corporate', 'qiita', 'zenn', 'note', 'devto', 'hashnode'
+  canonical_url TEXT,
+  published_url TEXT,
+  status TEXT CHECK (status IN ('published', 'failed', 'unpublished')),
+  published_at TIMESTAMPTZ
+)
+```
+
+Relationships:
+- 1 idea -> 2 drafts (JA + EN)
+- 1 draft -> N publications (JA draft -> corporate/qiita/zenn/note, EN draft -> corporate/devto/hashnode)
+- conversation_ids traces back to source material (useful for future book compilation)
+
+## Platform Adapters
+
+| Adapter | Language | Method | Canonical URL |
+|---------|----------|--------|---------------|
+| **corporate** | ja/en | Git push -> Next.js build (ISR/SSG) | This IS the canonical |
+| **qiita** | ja | REST API v2 | corporate JA URL |
+| **zenn** | ja | GitHub repo push | Footer link (no canonical support) |
+| **note** | ja | Playwright headless browser | Footer link (no API) |
+| **devto** | en | Forem REST API (`canonical_url` field) | corporate EN URL |
+| **hashnode** | en | GraphQL API (`originalArticleURL`) | corporate EN URL |
+| **x** | ja/en | X API v2 (`twitter-api-v2`) Free tier | Link to corporate |
+| **instagram-feed** | ja/en | Instagram Graph API | Link to corporate |
+| **instagram-stories** | ja/en | Ayrshare API ($29/month) | N/A (visual only) |
+
+### SNS Adapters (X + Instagram)
+
+Two posting modes for SNS adapters:
+1. **Article promotion** — "New article published" + excerpt + URL to corporate site. Auto-generated when a blog article is published.
+2. **Standalone post** — Independent SNS content (text + image). Can be triggered manually or generated from conversation insights.
+
+### X (Twitter) Adapter
+
+- Library: `twitter-api-v2` (TypeScript native)
+- Auth: OAuth 1.0a (Free tier: 1,500 tweets/month, $0)
+- Supports: text, text + image (via media upload v1.1), link cards (automatic from URL)
+- Rate limit: 200 requests/15min per user
+
+### Instagram Feed Adapter
+
+- Method: Instagram Graph API direct (`POST /{ig-user-id}/media` → `POST /{ig-user-id}/media_publish`)
+- Requirements: Instagram Business Account + Facebook Page + App Review
+- Supports: single image, carousel, reels
+- Constraint: image must be hosted at public URL (upload to corporate site or R2 first)
+- Rate limit: 25 posts/24h
+- Cost: $0
+
+### Instagram Stories Adapter
+
+- Method: Ayrshare API (official Instagram partner)
+- Cost: ~$29/month
+- Supports: image stories, video stories
+- Simple REST API: `POST /api/post` with `isStory: true`
+
+### note.com Special Handling
+
+note has no public API. Publish via Playwright headless browser automation. Fallback to manual if automation breaks.
+
+### Zenn Special Handling
+
+Zenn uses GitHub integration only (no API). Push Markdown to a dedicated Zenn repository. Canonical URL not supported by Zenn; include original link in article footer.
+
+## Tech Stack
+
+- All TypeScript (no Python in pipeline containers)
+- LLM: Claude API (Anthropic SDK) for generation and review
+- DB: Existing PostgreSQL + pgvector
+- Slack: `@slack/web-api`
+- X: `twitter-api-v2`
+- Instagram: Graph API direct + Ayrshare API (Stories)
+- Playwright: note.com adapter only
+- Single multi-stage Dockerfile
+- Docker Compose service: `pipeline`
+
+## SEO Strategy
+
+- Corporate site is canonical source for all articles
+- Same content across platforms is fine with canonical URLs set correctly
+- Multi-language content is NOT duplicate (Google treats different languages as separate)
+- hreflang tags on corporate site to cross-reference JA/EN versions
+
+## Content Strategy
+
+- **Theme**: Claude Code mastery, AI-assisted development
+- **Tone**: Failure-first storytelling. "I tried X, it broke because Y, finally Z worked"
+- **Audience JA**: Engineers (Qiita/Zenn), business/non-tech (note), general (X/Instagram)
+- **Audience EN**: Global dev community (dev.to/Hashnode), general (X/Instagram)
+- **SNS strategy**: Article promotions + standalone insights. X for tech audience, Instagram for broader reach
+- **Future**: Article metadata (theme, timeline, tags) enables automatic book chapter proposal
+
+## Verification Plan
+
+1. **Scanner**: Run against existing conversation data, verify topic extraction quality
+2. **Generator**: Feed 1 idea manually, verify JA/EN article output quality
+3. **Reviewer**: Pass generated articles through LLM review, verify pass/fail accuracy
+4. **Adapters**: Test publish to each platform in draft mode
+5. **E2E**: Full cron -> scan -> generate -> review -> publish -> Slack notification flow
+6. **Backfill**: Run full history scan, verify idea dedup and volume
+
+## Pre-Implementation: Manual First Article
+
+Before building any of this pipeline, manually write and publish 1 article using Claude Code conversation. This validates:
+- Article tone and structure
+- Reader reception
+- Platform publishing flow (manual)
+
+Only proceed to pipeline implementation after the first article is published and evaluated.


### PR DESCRIPTION
Part of the org-wide funding cleanup: org repos inherit the single org Source of Truth (`agiletec-inc/.github/FUNDING.yml`); personal accounts stay in their own context.

## Changes
- Remove the README `💖 Support This Project` section. It pointed at personal accounts (`buymeacoffee.com/kazukinakad`, `github.com/sponsors/kazukinakad`) — and `github.com/sponsors/kazukinakad` is a **dead handle** (no such GitHub user). The Sponsor button now inherits the org default.
- Fix the install clone URL: `github.com/kazukinakai/mindbase` → `github.com/agiletec-inc/mindbase` (canonical repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)