### PR TITLE
feat(cli): Claude Code memory hooks (event-driven ingest + context recall)

### DIFF
--- a/apps/cli/claude-code.ts
+++ b/apps/cli/claude-code.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared helpers for Claude Code transcript handling.
+ *
+ * Used by:
+ *   - commands/collect.ts  (full scan + single-file ingest)
+ *   - commands/hook.ts      (SessionEnd ingest, SessionStart recall)
+ *
+ * Claude Code stores one JSONL transcript per session at
+ *   ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl
+ * where <encoded-cwd> is the absolute cwd with every "/" replaced by "-".
+ */
+
+import { readFile } from 'fs/promises';
+
+const API_URL = process.env.MINDBASE_API_URL || 'http://api:18003';
+
+export interface CollectedConversation {
+  source: string;
+  title: string;
+  content: { messages: Array<{ role: string; content: string; timestamp?: string }> };
+  metadata: Record<string, any>;
+  source_conversation_id: string;
+  project?: string;
+}
+
+export interface SearchResult {
+  id: string;
+  title: string | null;
+  source: string;
+  similarity: number;
+  workspace_path: string | null;
+  created_at: string;
+  content_preview: string | null;
+}
+
+/** Decode a Claude Code project directory name back into an approximate path. */
+export function decodeProjectName(entry: string): string {
+  return decodeURIComponent(entry.replace(/-/g, '/'));
+}
+
+/** Encode an absolute cwd into the Claude Code project directory name. */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/\//g, '-');
+}
+
+/**
+ * Parse one Claude Code session JSONL into a CollectedConversation.
+ * Returns null when the file has no user/assistant messages.
+ * `entry` is the project directory name (used for the dedup id).
+ */
+export async function buildConversation(
+  filePath: string,
+  entry: string,
+  jsonlFile: string,
+): Promise<CollectedConversation | null> {
+  const content = await readFile(filePath, 'utf-8');
+  const lines = content.trim().split('\n').filter((l) => l.trim());
+
+  const messages: Array<{ role: string; content: string; timestamp?: string }> = [];
+
+  for (const line of lines) {
+    try {
+      const data = JSON.parse(line);
+      if (data.type === 'user' || data.type === 'assistant') {
+        const msgContent = typeof data.message?.content === 'string'
+          ? data.message.content
+          : typeof data.message === 'string'
+            ? data.message
+            : JSON.stringify(data.message || data.content || '');
+
+        if (msgContent) {
+          messages.push({
+            role: data.type,
+            content: msgContent,
+            timestamp: data.timestamp,
+          });
+        }
+      }
+    } catch {
+      // Skip invalid JSON lines
+    }
+  }
+
+  if (messages.length === 0) return null;
+
+  const firstUser = messages.find((m) => m.role === 'user');
+  const title = firstUser
+    ? firstUser.content.substring(0, 100) + (firstUser.content.length > 100 ? '...' : '')
+    : `Claude Code session (${jsonlFile})`;
+
+  return {
+    source: 'claude-code',
+    title,
+    content: { messages },
+    metadata: { file: jsonlFile },
+    source_conversation_id: `${entry}/${jsonlFile}`,
+    project: decodeProjectName(entry),
+  };
+}
+
+/** POST a conversation to the MindBase API. Returns true on success. */
+export async function storeConversation(conv: CollectedConversation): Promise<boolean> {
+  const response = await fetch(`${API_URL}/conversations/store`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(conv),
+  });
+  if (response.ok) return true;
+  const errText = await response.text();
+  console.error(`  Failed to store "${conv.title}": ${response.status} ${errText}`);
+  return false;
+}
+
+/**
+ * Semantic search via the MindBase API, optionally scoped to a workspace path.
+ * `timeoutMs` keeps a SessionStart hook from stalling shell startup when the
+ * API is slow or down — on timeout/error it throws and the caller no-ops.
+ */
+export async function searchConversations(
+  query: string,
+  opts: { workspacePath?: string; limit?: number; threshold?: number; timeoutMs?: number } = {},
+): Promise<SearchResult[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 3000);
+  try {
+    const response = await fetch(`${API_URL}/conversations/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        limit: opts.limit ?? 5,
+        threshold: opts.threshold ?? 0.5,
+        workspace_path: opts.workspacePath,
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`search failed: ${response.status}`);
+    return (await response.json()) as SearchResult[];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/cli/commands/collect.ts
+++ b/apps/cli/commands/collect.ts
@@ -4,24 +4,24 @@
  * TypeScript native implementation (no Python dependency).
  * Reads JSONL directly from ~/.claude/projects/ and POSTs to the MindBase API.
  *
- * Usage: mindbase collect [--source claude-code] [--since 2026-01-01] [--dry-run]
+ * Usage:
+ *   mindbase collect [--source claude-code] [--since 2026-01-01] [--dry-run]
+ *   mindbase collect --file ~/.claude/projects/<proj>/<session>.jsonl   # single session
+ *
+ * The single-file mode is used by the SessionEnd hook to ingest just the
+ * session that ended. Dedup on the API side ((source, source_conversation_id))
+ * makes both modes idempotent.
  */
 
 import { parseArgs } from 'node:util';
-import { readFile, readdir, stat } from 'fs/promises';
-import { join } from 'path';
+import { readdir, stat } from 'fs/promises';
+import { join, basename, dirname } from 'path';
 import { homedir } from 'os';
-
-const API_URL = process.env.MINDBASE_API_URL || 'http://api:18003';
-
-interface CollectedConversation {
-  source: string;
-  title: string;
-  content: { messages: Array<{ role: string; content: string; timestamp?: string }> };
-  metadata: Record<string, any>;
-  source_conversation_id: string;
-  project?: string;
-}
+import {
+  type CollectedConversation,
+  buildConversation,
+  storeConversation,
+} from '../claude-code.js';
 
 export async function run() {
   const { values } = parseArgs({
@@ -29,6 +29,7 @@ export async function run() {
     options: {
       source: { type: 'string', short: 's', default: 'claude-code' },
       since: { type: 'string' },
+      file: { type: 'string' },
       'dry-run': { type: 'boolean' },
     },
     strict: true,
@@ -38,6 +39,37 @@ export async function run() {
     console.error(`Only "claude-code" source is supported in CLI. Got: ${values.source}`);
     console.error('For other sources, use the Python collector: scripts/collect-conversations.py');
     process.exit(1);
+  }
+
+  // Single-file mode: ingest just one session transcript (used by the SessionEnd hook).
+  if (values.file) {
+    const filePath = values.file;
+    const jsonlFile = basename(filePath);
+    const entry = basename(dirname(filePath));
+
+    let conv: CollectedConversation | null;
+    try {
+      conv = await buildConversation(filePath, entry, jsonlFile);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Cannot read ${filePath}: ${msg}`);
+      process.exit(1);
+    }
+
+    if (!conv) {
+      console.log(`No user/assistant messages in ${jsonlFile} — nothing to store`);
+      return;
+    }
+
+    if (values['dry-run']) {
+      console.log(`Dry run — [${conv.project}] ${conv.title} (${conv.content.messages.length} messages)`);
+      return;
+    }
+
+    const ok = await storeConversation(conv);
+    console.log(ok ? `Stored: ${conv.title}` : 'Store failed');
+    if (!ok) process.exit(1);
+    return;
   }
 
   const sinceDate = values.since ? new Date(values.since) : undefined;
@@ -63,10 +95,6 @@ export async function run() {
     const projectStat = await stat(projectPath).catch(() => null);
     if (!projectStat?.isDirectory()) continue;
 
-    // Decode project name from path encoding
-    const projectName = decodeURIComponent(entry.replace(/-/g, '/'));
-
-    // Find JSONL files
     const files = await readdir(projectPath).catch(() => []);
     const jsonlFiles = files.filter((f) => f.endsWith('.jsonl'));
 
@@ -78,50 +106,8 @@ export async function run() {
       if (sinceDate && fileStat && fileStat.mtime < sinceDate) continue;
 
       try {
-        const content = await readFile(filePath, 'utf-8');
-        const lines = content.trim().split('\n').filter((l) => l.trim());
-
-        const messages: Array<{ role: string; content: string; timestamp?: string }> = [];
-
-        for (const line of lines) {
-          try {
-            const data = JSON.parse(line);
-            if (data.type === 'user' || data.type === 'assistant') {
-              const msgContent = typeof data.message?.content === 'string'
-                ? data.message.content
-                : typeof data.message === 'string'
-                  ? data.message
-                  : JSON.stringify(data.message || data.content || '');
-
-              if (msgContent) {
-                messages.push({
-                  role: data.type,
-                  content: msgContent,
-                  timestamp: data.timestamp,
-                });
-              }
-            }
-          } catch {
-            // Skip invalid JSON lines
-          }
-        }
-
-        if (messages.length > 0) {
-          // Generate title from first user message
-          const firstUser = messages.find((m) => m.role === 'user');
-          const title = firstUser
-            ? firstUser.content.substring(0, 100) + (firstUser.content.length > 100 ? '...' : '')
-            : `Claude Code session (${jsonlFile})`;
-
-          conversations.push({
-            source: 'claude-code',
-            title,
-            content: { messages },
-            metadata: { file: jsonlFile },
-            source_conversation_id: `${entry}/${jsonlFile}`,
-            project: projectName,
-          });
-        }
+        const conv = await buildConversation(filePath, entry, jsonlFile);
+        if (conv) conversations.push(conv);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`  Error reading ${filePath}: ${msg}`);
@@ -148,19 +134,9 @@ export async function run() {
 
   for (const conv of conversations) {
     try {
-      const response = await fetch(`${API_URL}/conversations/store`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(conv),
-      });
-
-      if (response.ok) {
-        successes++;
-      } else {
-        failures++;
-        const errText = await response.text();
-        console.error(`  Failed to store "${conv.title}": ${response.status} ${errText}`);
-      }
+      const ok = await storeConversation(conv);
+      if (ok) successes++;
+      else failures++;
     } catch (err) {
       failures++;
       const msg = err instanceof Error ? err.message : String(err);

--- a/apps/cli/commands/hook.ts
+++ b/apps/cli/commands/hook.ts
@@ -1,0 +1,152 @@
+/**
+ * hook command — Claude Code lifecycle hook handlers.
+ *
+ * Wired into ~/.claude/settings.json by `mindbase install` (see commands/install.ts):
+ *   SessionEnd   -> mindbase hook session-end    (ingest the session that just ended)
+ *   SessionStart -> mindbase hook session-start  (inject relevant past context)
+ *
+ * Both read the hook event JSON from stdin (Claude Code passes session_id,
+ * transcript_path, cwd, ...). Both are NON-BLOCKING: any failure (API down,
+ * missing file, timeout) exits 0 silently so a session is never broken.
+ *
+ * Usage (invoked by Claude Code, not by hand):
+ *   echo '<hook-json>' | mindbase hook session-end
+ *   echo '<hook-json>' | mindbase hook session-start
+ */
+
+import { readdir, stat } from 'fs/promises';
+import { join, basename, dirname } from 'path';
+import { homedir } from 'os';
+import {
+  buildConversation,
+  storeConversation,
+  searchConversations,
+  encodeProjectDir,
+  type SearchResult,
+} from '../claude-code.js';
+
+interface HookInput {
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  hook_event_name?: string;
+}
+
+async function readStdin(): Promise<HookInput> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as HookInput;
+  } catch {
+    return {};
+  }
+}
+
+/** SessionEnd: ingest the transcript of the session that just ended. */
+async function sessionEnd(input: HookInput): Promise<void> {
+  const filePath = input.transcript_path;
+  if (!filePath) return;
+
+  const jsonlFile = basename(filePath);
+  const entry = basename(dirname(filePath));
+
+  const conv = await buildConversation(filePath, entry, jsonlFile);
+  if (!conv) return;
+  await storeConversation(conv);
+}
+
+/**
+ * SessionStart: find the most recent PRIOR session in this workspace, use its
+ * last user message as the query, and inject the top matches as additionalContext.
+ */
+async function sessionStart(input: HookInput): Promise<void> {
+  const cwd = input.cwd;
+  if (!cwd) return;
+
+  const projectDir = join(homedir(), '.claude', 'projects', encodeProjectDir(cwd));
+  let files: string[];
+  try {
+    files = (await readdir(projectDir)).filter((f) => f.endsWith('.jsonl'));
+  } catch {
+    return; // no prior sessions for this workspace
+  }
+
+  // Exclude the current session's own transcript, if it already exists.
+  const currentFile = input.session_id ? `${input.session_id}.jsonl` : null;
+  const candidates = files.filter((f) => f !== currentFile);
+  if (candidates.length === 0) return;
+
+  // Most recently modified prior transcript.
+  const withMtime = await Promise.all(
+    candidates.map(async (f) => {
+      const s = await stat(join(projectDir, f)).catch(() => null);
+      return { f, mtime: s ? s.mtimeMs : 0 };
+    }),
+  );
+  withMtime.sort((a, b) => b.mtime - a.mtime);
+  const recent = withMtime[0].f;
+
+  const conv = await buildConversation(join(projectDir, recent), basename(projectDir), recent);
+  if (!conv) return;
+  // Use the last genuine user prompt as the query. Skip tool-result turns, which
+  // Claude Code also logs as role "user" but whose content is a JSON blob — those
+  // make poor semantic queries.
+  const lastPrompt = [...conv.content.messages].reverse().find((m) => {
+    if (m.role !== 'user') return false;
+    const c = m.content.trimStart();
+    return c.length > 0 && !c.startsWith('[') && !c.startsWith('{');
+  });
+  const query = lastPrompt?.content?.trim();
+  if (!query) return;
+
+  const results = await searchConversations(query.slice(0, 500), {
+    workspacePath: cwd,
+    limit: 5,
+  });
+  if (results.length === 0) return;
+
+  emitContext(results);
+}
+
+function emitContext(results: SearchResult[]): void {
+  const lines = results.map((r) => {
+    const date = (r.created_at || '').slice(0, 10);
+    const preview = (r.content_preview || '').replace(/\s+/g, ' ').slice(0, 200);
+    return `- [${date}] ${r.title ?? 'untitled'}\n  ${preview}`;
+  });
+  const additionalContext =
+    'Relevant past conversations from this workspace (via MindBase memory):\n' +
+    lines.join('\n');
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext,
+      },
+    }),
+  );
+}
+
+export async function run() {
+  const sub = process.argv[3];
+  const input = await readStdin();
+
+  try {
+    if (sub === 'session-end') {
+      await sessionEnd(input);
+    } else if (sub === 'session-start') {
+      await sessionStart(input);
+    } else {
+      console.error('Usage: mindbase hook <session-end|session-start>');
+      process.exit(1);
+    }
+  } catch (err) {
+    // Non-blocking: never fail a Claude Code session because of memory I/O.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`mindbase hook ${sub}: ${msg}`);
+  }
+  process.exit(0);
+}

--- a/apps/cli/commands/install.ts
+++ b/apps/cli/commands/install.ts
@@ -1,0 +1,88 @@
+/**
+ * install command — Install MindBase memory hooks into Claude Code.
+ *
+ * Writes SessionStart + SessionEnd hook entries into ~/.claude/settings.json so
+ * that, with no manual steps, every Claude Code session:
+ *   - SessionEnd   -> ingests its transcript into MindBase
+ *   - SessionStart -> injects relevant past context for the workspace
+ *
+ * Idempotent and non-destructive: only entries owned by THIS MindBase checkout
+ * (identified by the absolute CLI path in the command) are added/replaced. Any
+ * other hooks the user has are left untouched. `uninstall` reverses it exactly.
+ *
+ * Usage:
+ *   mindbase install [--api-url http://localhost:18002] [--settings <path>]
+ *
+ * ~/.claude is NOT version-controlled, so this installer lives in the MindBase
+ * repo and regenerates the exact configuration on demand — that is the source
+ * of reproducibility, not the hand-edited settings file.
+ */
+
+import { parseArgs } from 'node:util';
+import { readFile, writeFile, access } from 'fs/promises';
+import { join, dirname, resolve } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+
+interface HookCommand { type: 'command'; command: string }
+interface HookEntry { matcher?: string; hooks: HookCommand[] }
+
+const CLI_ENTRY = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'index.ts');
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const TSX = join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+
+/** A hook entry belongs to this installer if its command references our CLI_ENTRY. */
+function isOurs(entry: HookEntry): boolean {
+  return entry.hooks?.some((h) => typeof h.command === 'string' && h.command.includes(CLI_ENTRY));
+}
+
+function hookCommand(sub: string, apiUrl: string): string {
+  return `MINDBASE_API_URL=${apiUrl} "${TSX}" "${CLI_ENTRY}" hook ${sub}`;
+}
+
+export async function run() {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      'api-url': { type: 'string', default: process.env.MINDBASE_API_URL || 'http://localhost:18002' },
+      settings: { type: 'string' },
+    },
+    strict: true,
+  });
+
+  const apiUrl = values['api-url']!;
+  const settingsPath = values.settings || join(homedir(), '.claude', 'settings.json');
+
+  // Warn (don't fail) if tsx isn't installed yet — hooks need it to run.
+  await access(TSX).catch(() => {
+    console.warn(`⚠️  tsx not found at ${TSX}`);
+    console.warn('   Run `pnpm install` in the MindBase repo so the hooks can execute.');
+  });
+
+  let settings: Record<string, any> = {};
+  try {
+    settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+  } catch {
+    // missing or empty -> start fresh, preserving nothing to clobber
+  }
+
+  settings.hooks ??= {};
+  const hooks = settings.hooks as Record<string, HookEntry[]>;
+
+  const install = (event: string, matcher: string, sub: string) => {
+    const existing = (hooks[event] ?? []).filter((e) => !isOurs(e));
+    existing.push({ matcher, hooks: [{ type: 'command', command: hookCommand(sub, apiUrl) }] });
+    hooks[event] = existing;
+  };
+
+  install('SessionEnd', '', 'session-end');
+  install('SessionStart', 'startup|resume', 'session-start');
+
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+
+  console.log(`Installed MindBase memory hooks → ${settingsPath}`);
+  console.log(`  API: ${apiUrl}`);
+  console.log('  SessionEnd   → ingest transcript');
+  console.log('  SessionStart → inject relevant past context (startup|resume)');
+  console.log('Run `mindbase uninstall` to remove.');
+}

--- a/apps/cli/commands/uninstall.ts
+++ b/apps/cli/commands/uninstall.ts
@@ -1,0 +1,60 @@
+/**
+ * uninstall command — Remove MindBase memory hooks from Claude Code.
+ *
+ * Reverses `install`: drops only the SessionStart/SessionEnd entries owned by
+ * THIS MindBase checkout (identified by the absolute CLI path), leaves every
+ * other hook intact, and removes an event key entirely if it becomes empty.
+ *
+ * Usage:
+ *   mindbase uninstall [--settings <path>]
+ */
+
+import { parseArgs } from 'node:util';
+import { readFile, writeFile } from 'fs/promises';
+import { join, dirname, resolve } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+
+interface HookCommand { type: 'command'; command: string }
+interface HookEntry { matcher?: string; hooks: HookCommand[] }
+
+const CLI_ENTRY = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'index.ts');
+
+function isOurs(entry: HookEntry): boolean {
+  return entry.hooks?.some((h) => typeof h.command === 'string' && h.command.includes(CLI_ENTRY));
+}
+
+export async function run() {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: { settings: { type: 'string' } },
+    strict: true,
+  });
+
+  const settingsPath = values.settings || join(homedir(), '.claude', 'settings.json');
+
+  let settings: Record<string, any>;
+  try {
+    settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+  } catch {
+    console.log(`No settings file at ${settingsPath} — nothing to remove.`);
+    return;
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, HookEntry[]>;
+  let removed = 0;
+
+  for (const event of ['SessionStart', 'SessionEnd']) {
+    const entries = hooks[event];
+    if (!Array.isArray(entries)) continue;
+    const kept = entries.filter((e) => !isOurs(e));
+    removed += entries.length - kept.length;
+    if (kept.length === 0) delete hooks[event];
+    else hooks[event] = kept;
+  }
+
+  if (Object.keys(hooks).length === 0) delete settings.hooks;
+
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+  console.log(`Removed ${removed} MindBase hook entr${removed === 1 ? 'y' : 'ies'} from ${settingsPath}`);
+}

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -41,23 +41,42 @@ async function main() {
       await run();
       break;
     }
+    case 'hook': {
+      const { run } = await import('./commands/hook.js');
+      await run();
+      break;
+    }
+    case 'install': {
+      const { run } = await import('./commands/install.js');
+      await run();
+      break;
+    }
+    case 'uninstall': {
+      const { run } = await import('./commands/uninstall.js');
+      await run();
+      break;
+    }
     default:
       console.log(`MindBase CLI v1.0.0
 
 Usage: mindbase <command> [options]
 
 Commands:
-  generate  Generate article from conversation data
-  publish   Publish article to platform
-  search    Search conversations
-  collect   Collect conversations from sources
-  status    Check service status
+  generate   Generate article from conversation data
+  publish    Publish article to platform
+  search     Search conversations
+  collect    Collect conversations from sources
+  status     Check service status
+  hook       Claude Code lifecycle hook handler (session-end | session-start)
+  install    Install Claude Code memory hooks into ~/.claude/settings.json
+  uninstall  Remove the Claude Code memory hooks
 
 Examples:
   mindbase generate --topic "Docker-First開発" --platform note
   mindbase publish --file generated/note/article.md --platform note --draft
   mindbase search --query "Docker" --limit 5
   mindbase collect --source claude-code
+  mindbase install --api-url http://localhost:18002
   mindbase status`);
       process.exit(command ? 1 : 0);
   }


### PR DESCRIPTION
## What

Turns past Claude Code sessions into MindBase long-term memory and recalls them automatically — as a **reproducible, repo-managed** feature (no hand-edited `~/.claude` config).

- **`collect --file <path>`** — single-session ingest (idempotent via the API's `(source, source_conversation_id)` dedup). Shared parse/store helpers extracted to `apps/cli/claude-code.ts` so full-scan and single-file stay identical.
- **`hook session-end`** — ingest the transcript of the session that just ended.
- **`hook session-start`** — use the last real user prompt of the most recent prior session in the workspace as a query, semantic-search MindBase, inject top matches as `SessionStart` `additionalContext` (cwd-scoped).
- **`install` / `uninstall`** — idempotently merge `SessionStart`+`SessionEnd` entries into `~/.claude/settings.json`, owning only entries that reference this checkout's CLI path. Other user hooks preserved; uninstall reverses exactly.

Both hooks are **non-blocking**: API down / missing file / 3s timeout → `exit 0`, never breaking a session.

## Why

`~/.claude` isn't version-controlled, so hand-placed hooks aren't reproducible. The installer lives in the repo and regenerates the exact config on demand. MindBase already has the collectors, `/conversations/store`, pgvector search, MCP server, and gateway registration — this wires Claude Code's lifecycle to them.

## Verification (real flow)

- `install` ×2 → no duplicate entry; preserves a pre-existing user hook; `uninstall` removes only ours.
- `collect --file` parses a real transcript (181 messages).
- `hook session-start` emits valid `additionalContext` JSON against a live API (`agiletec-inc` workspace); no-ops when nothing relevant.
- `hook session-end` no-ops (exit 0) when the API is down.
- `tsc --noEmit` clean for these files.

Final acceptance is the user running `mindbase install --api-url <url>` and observing a real session.

## Follow-up (not here)

- launchd `WatchPaths` backstop for sessions a hook missed.
- Generalize ingest to other tools' transcript dirs (collectors already exist).
- Ship a built CLI binary so the hook command needn't reference `node_modules/.bin/tsx`.