### PR TITLE
feat(embeddings): single-SSoT, runtime-switchable embedding model + compare API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,13 +24,12 @@ EMBEDDING_MODEL=bge-m3
 # Head-truncate embedding input to this many chars (models have a fixed context
 # window and error on overflow). On overflow the input is halved and retried.
 EMBEDDING_MAX_CHARS=8000
-# EMBEDDING_DIMENSIONS is auto-detected from model name if not set:
-#   - nomic-embed-text: 768
-#   - qwen3-embedding: 1024
-#   - text-embedding-ada-002: 1536
-#   - text-embedding-3-large: 3072
-# Override only if using a custom model
-EMBEDDING_DIMENSIONS=1024
+# EMBEDDING_DIMENSIONS is derived automatically from the embedding vector length
+# (each model writes to its dim-bucket column: vec_768 / vec_1024 / vec_3072 / vec_4096).
+# Reference dims: nomic-embed-text 768 | bge-m3 / mxbai-embed-large 1024 |
+# text-embedding-3-large 3072 | qwen3-embedding:8b 4096. You normally do not set this;
+# uncomment only to override the legacy single-vector column.
+# EMBEDDING_DIMENSIONS=1024
 
 # FastAPI Configuration
 API_HOST=0.0.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,6 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://mindbase:mindbase_dev@localhost:5432/mindbase_test
           OLLAMA_URL: http://localhost:11434
-          EMBEDDING_MODEL: qwen3-embedding:8b
-          EMBEDDING_DIMENSIONS: 4096
         run: uv run pytest tests/ -v
 
       - name: Run TypeScript type check

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://www.docker.com/)
 
-> **100 % local, zero vendor lock-in.** PostgreSQL 17 + pgvector + FastAPI + Ollama (qwen3-embedding:8b). No API keys, no hosted dependencies, completely free to run on your own machine.
+> **100 % local, zero vendor lock-in.** PostgreSQL 17 + pgvector + FastAPI + Ollama (default `bge-m3`, switchable to any catalog model — `qwen3-embedding:8b`, `mxbai-embed-large`, … — from Settings). No API keys, no hosted dependencies, completely free to run on your own machine.
 
 ## 🌟 Part of the AIRIS Ecosystem
 
@@ -66,7 +66,7 @@ Because AIRIS only loads tool instructions when the model actually chooses MindB
 
 1. **Unified timeline** – Collectors pull logs from editors, desktop clients, terminal agents, and any bespoke transcripts. Everything lands in one ordered ledger so you can replay how a project evolved across assistants.
 2. **Project & topic intelligence** – Stored metadata keeps conversations grouped by project, topic, and source. You can trace a task from brainstorming in Claude Desktop to implementation inside Cursor without manual tagging.
-3. **Semantic memory** – Messages are embedded locally through Ollama’s qwen3-embedding:8b model and stored in pgvector. MindBase becomes the long-term recall layer for AIRIS tools, MCP servers, or any downstream automation.
+3. **Semantic memory** – Messages are embedded locally through Ollama (default `bge-m3`, switchable per the model catalog) and stored in pgvector. Vectors from different models coexist per conversation, so you can re-embed and compare models. MindBase becomes the long-term recall layer for AIRIS tools, MCP servers, or any downstream automation.
 4. **Local-first privacy** – Conversations reside only inside your Dockerized PostgreSQL volume. Nothing writes to `~/Library/Application Support` or remote services, so your chat history never leaks into cloud sync folders.
 
 ## Architecture overview
@@ -106,7 +106,7 @@ Because AIRIS only loads tool instructions when the model actually chooses MindB
                 │ local embedding calls
                 ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ Ollama (qwen3-embedding:8b)                                              │
+│ Ollama (default bge-m3 · switchable model)                               │
 │  - Fully on-device                                                       │
 │  - Runs free of charge                                                   │
 └───────────────┬──────────────────────────────────────────────────────────┘

--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -11,6 +11,9 @@ from apps.api import crud
 from apps.api.database import get_db
 from apps.api.ollama_client import ollama_client
 from apps.api.schemas.conversation import (
+    CompareModelResults,
+    CompareRequest,
+    CompareResponse,
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
@@ -19,6 +22,7 @@ from apps.api.schemas.conversation import (
     SearchQuery,
     SearchResult,
 )
+from apps.api.services import settings_store
 from apps.api.services.deriver import (
     _extract_text_from_content,
     process_raw_conversation,
@@ -27,6 +31,31 @@ from apps.api.services.deriver import (
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+
+def _format_result(row) -> SearchResult:
+    """Map a search row to a SearchResult with a short content preview."""
+    if "messages" in row.content:
+        messages = row.content["messages"]
+        first_message = messages[0].get("content", "") if messages else ""
+        preview = (
+            first_message[:200] + "..." if len(first_message) > 200 else first_message
+        )
+    else:
+        content_str = str(row.content)
+        preview = content_str[:200] + "..." if len(content_str) > 200 else content_str
+    return SearchResult(
+        id=row.id,
+        title=row.title,
+        source=row.source,
+        project=row.project,
+        topics=row.topics or [],
+        similarity=row.similarity,
+        workspace_path=row.workspace_path,
+        raw_id=row.raw_id,
+        created_at=row.created_at,
+        content_preview=preview,
+    )
 
 
 @router.post("/store", response_model=ConversationResponse | ConversationQueuedResponse)
@@ -90,9 +119,16 @@ async def search_conversations_endpoint(
     """
     try:
         # Resolve provider/model: the query must be embedded with the same model
-        # whose stored vectors we search against.
-        provider = query.provider or ollama_client.active_provider
-        model = query.model or ollama_client.default_model(provider)
+        # whose stored vectors we search against. Defaults come from the active
+        # embedding (single source of truth), overridable per request.
+        active_provider, active_model = settings_store.get_active_embedding()
+        provider = query.provider or active_provider
+        if query.model:
+            model = query.model
+        elif provider == active_provider:
+            model = active_model
+        else:
+            model = ollama_client.default_model(provider)
 
         query_embedding = await ollama_client.embed(
             query.query, provider=provider, model=model
@@ -111,44 +147,60 @@ async def search_conversations_endpoint(
             workspace_path=query.workspace_path,
         )
 
-        # Format results
-        search_results = []
-        for row in results:
-            # Extract content preview
-            if "messages" in row.content:
-                messages = row.content["messages"]
-                first_message = messages[0].get("content", "") if messages else ""
-                preview = (
-                    first_message[:200] + "..."
-                    if len(first_message) > 200
-                    else first_message
-                )
-            else:
-                content_str = str(row.content)
-                preview = (
-                    content_str[:200] + "..." if len(content_str) > 200 else content_str
-                )
-
-            search_results.append(
-                SearchResult(
-                    id=row.id,
-                    title=row.title,
-                    source=row.source,
-                    project=row.project,
-                    topics=row.topics or [],
-                    similarity=row.similarity,
-                    workspace_path=row.workspace_path,
-                    raw_id=row.raw_id,
-                    created_at=row.created_at,
-                    content_preview=preview,
-                )
-            )
-
-        return search_results
+        return [_format_result(row) for row in results]
 
     except Exception as exc:  # pragma: no cover
         logger.exception("Failed to search conversations")
         raise HTTPException(status_code=500, detail=f"Search failed: {exc}") from exc
+
+
+@router.post("/compare", response_model=CompareResponse)
+async def compare_models(request: CompareRequest, db: AsyncSession = Depends(get_db)):
+    """
+    Run one query against several embedding models, side by side.
+
+    Each model embeds the query and searches only its own stored vectors
+    (per-model coexistence in conversation_embeddings), so you can eyeball recall
+    and ranking differences for accuracy validation. Backfill coverage first with
+    POST /conversations/reembed. A model that can't be embedded yields an `error`
+    entry instead of failing the whole comparison.
+    """
+    models_out: list[CompareModelResults] = []
+    for spec in request.models:
+        provider = spec.provider
+        model = spec.model or ollama_client.default_model(provider)
+        try:
+            query_embedding = await ollama_client.embed(
+                request.query, provider=provider, model=model
+            )
+            rows = await crud.search_conversation_embeddings(
+                db=db,
+                query_embedding=query_embedding,
+                provider=provider,
+                model=model,
+                limit=request.limit,
+                threshold=request.threshold,
+                source=request.source,
+                project=request.project,
+                topic=request.topic,
+                workspace_path=request.workspace_path,
+            )
+            models_out.append(
+                CompareModelResults(
+                    provider=provider,
+                    model=model,
+                    results=[_format_result(row) for row in rows],
+                )
+            )
+        except Exception as exc:  # pragma: no cover - per-model isolation
+            logger.exception("compare: model %s/%s failed", provider, model)
+            models_out.append(
+                CompareModelResults(
+                    provider=provider, model=model, results=[], error=str(exc)
+                )
+            )
+
+    return CompareResponse(query=request.query, models=models_out)
 
 
 @router.post("/reembed", response_model=ReembedResponse)

--- a/apps/api/api/routes/embeddings.py
+++ b/apps/api/api/routes/embeddings.py
@@ -3,7 +3,6 @@
 from fastapi import APIRouter, HTTPException
 
 from apps.api.ollama_client import ollama_client
-from apps.api.config import get_settings
 from apps.api.api.schemas.embeddings import (
     EmbeddingGenerateRequest,
     EmbeddingGenerateResponse,
@@ -15,11 +14,11 @@ from apps.api.api.schemas.embeddings import (
     ModelSwitchResponse,
     SystemSpecsResponse,
 )
+from apps.api.services import settings_store
 from apps.api.services.hardware import detect_hardware, recommend_models
 from apps.api.services.model_catalog import MODEL_CATALOG
 
 router = APIRouter(prefix="/api/embeddings", tags=["embeddings"])
-settings = get_settings()
 
 
 @router.get("/models", response_model=ModelListResponse)
@@ -54,7 +53,7 @@ async def list_models():
         ]
 
         return ModelListResponse(
-            current=settings.EMBEDDING_MODEL,
+            current=settings_store.get_active_embedding()[1],
             available=available,
             hardware={
                 "platform": hardware["platform"],
@@ -114,8 +113,16 @@ async def switch_active_model(request: ModelSwitchRequest):
                 detail=f"Model not installed: {request.model}. Run POST /api/embeddings/models/install first.",
             )
 
-        previous_model = ollama_client.model
-        ollama_client.model = request.model
+        previous_model = settings_store.get_active_embedding()[1]
+        # Cloud-catalog models (text-embedding-3-large) are OpenAI; the rest Ollama.
+        provider = (
+            "openai"
+            if MODEL_CATALOG[request.model].get("size") == "cloud"
+            else "ollama"
+        )
+        # Persist to the settings store (the single source of truth) so the switch
+        # survives a restart and takes effect without one.
+        settings_store.set_active_embedding(provider, request.model)
 
         return ModelSwitchResponse(
             status="success",
@@ -134,7 +141,7 @@ async def switch_active_model(request: ModelSwitchRequest):
 async def delete_model(model_name: str):
     """Remove an installed embedding model."""
     try:
-        if model_name == ollama_client.model:
+        if model_name == settings_store.get_active_embedding()[1]:
             raise HTTPException(
                 status_code=400,
                 detail=f"Cannot delete active model: {model_name}. Switch to another model first.",
@@ -197,11 +204,14 @@ async def get_system_specs():
 async def generate_embedding(request: EmbeddingGenerateRequest):
     """Generate an embedding vector for arbitrary text."""
     try:
-        embedding = await ollama_client.embed(request.text)
+        provider, model = settings_store.get_active_embedding()
+        embedding = await ollama_client.embed(
+            request.text, provider=provider, model=model
+        )
         return EmbeddingGenerateResponse(
             embedding=embedding,
             dimensions=len(embedding),
-            model=ollama_client.model,
+            model=model,
         )
     except Exception as e:  # pragma: no cover - surfaced via API response
         raise HTTPException(

--- a/apps/api/api/routes/settings.py
+++ b/apps/api/api/routes/settings.py
@@ -8,11 +8,17 @@ from apps.api.services import settings_store
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
+def _with_active_embedding(data: dict) -> AppSettings:
+    """Render AppSettings, always reflecting the live active embedding (SSoT)."""
+    provider, model = settings_store.get_active_embedding()
+    merged = {**data, "embeddingProvider": provider, "embeddingModel": model}
+    return AppSettings(**merged)
+
+
 @router.get("", response_model=AppSettings)
 async def get_settings() -> AppSettings:
-    data = settings_store.load_settings()
     try:
-        return AppSettings(**data)
+        return _with_active_embedding(settings_store.load_settings())
     except Exception as exc:
         raise HTTPException(
             status_code=500, detail=f"Invalid settings file: {exc}"
@@ -21,5 +27,14 @@ async def get_settings() -> AppSettings:
 
 @router.put("", response_model=AppSettings)
 async def update_settings(payload: AppSettings) -> AppSettings:
-    settings_store.save_settings(payload.model_dump())
-    return payload
+    # Merge over existing so omitted (null) fields don't clobber stored values.
+    merged = {**settings_store.load_settings(), **payload.model_dump(exclude_none=True)}
+    # Embedding selection goes through the single setter so the SSoT keys stay
+    # canonical and consistent with PUT /api/embeddings/models/active.
+    if payload.embeddingProvider or payload.embeddingModel:
+        current = settings_store.get_active_embedding()
+        provider = payload.embeddingProvider or current[0]
+        model = payload.embeddingModel or current[1]
+        merged["embeddingProvider"], merged["embeddingModel"] = provider, model
+    settings_store.save_settings(merged)
+    return _with_active_embedding(merged)

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -27,8 +27,13 @@ class Settings(BaseSettings):
 
     # Ollama Embedding
     OLLAMA_URL: str
-    EMBEDDING_MODEL: str
-    EMBEDDING_DIMENSIONS: int
+    # Seed default for the active embedding model. The live source of truth is the
+    # settings store (services/settings_store.get_active_embedding); this env value
+    # only seeds it when the store has no choice yet.
+    EMBEDDING_MODEL: str = "bge-m3"
+    # Vestigial: the real dimension is derived from the embedding vector length
+    # (crud.column_for_dim). Kept only for the legacy conversations.embedding column.
+    EMBEDDING_DIMENSIONS: int = 1024
 
     # Max characters of input text per embedding call. Embedding models have a
     # fixed context window (bge-m3: 8192 tokens) and error on overflow, so long

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -111,6 +111,14 @@ class AppSettings(BaseModel):
     refreshIntervalMs: int = Field(
         15000, description="Menubar poll interval in milliseconds"
     )
+    # Active embedding selection — the single source of truth (persisted here).
+    # Null means "unset": the API seeds these from env defaults on read.
+    embeddingProvider: Optional[str] = Field(
+        None, description="Active embedding provider: 'ollama' | 'openai'"
+    )
+    embeddingModel: Optional[str] = Field(
+        None, description="Active embedding model name (from the model catalog)"
+    )
     collectors: List[CollectorConfig] = Field(default_factory=list)
     pipelines: List[PipelineConfig] = Field(default_factory=list)
 
@@ -175,6 +183,53 @@ class SearchResult(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class CompareModel(BaseModel):
+    """One (provider, model) pair to evaluate in a comparison."""
+
+    provider: str = Field("ollama", description="Embedding provider: 'ollama'|'openai'")
+    model: Optional[str] = Field(
+        None, description="Model name; defaults to the provider's configured model"
+    )
+
+
+class CompareRequest(BaseModel):
+    """Run one query against several embedding models, side by side.
+
+    Each model searches only its own stored vectors (per-model coexistence in
+    conversation_embeddings). Backfill coverage first with POST /conversations/reembed
+    so every model has vectors to compare fairly.
+    """
+
+    query: str = Field(..., description="Search query text", min_length=1)
+    models: List[CompareModel] = Field(
+        ..., min_length=1, description="Models to compare for the same query"
+    )
+    limit: int = Field(10, ge=1, le=100)
+    threshold: float = Field(0.0, ge=0.0, le=1.0, description="Similarity threshold")
+    source: Optional[str] = None
+    project: Optional[str] = None
+    topic: Optional[str] = None
+    workspace_path: Optional[str] = None
+
+
+class CompareModelResults(BaseModel):
+    """Ranked results for a single model within a comparison."""
+
+    provider: str
+    model: str
+    results: List[SearchResult] = Field(default_factory=list)
+    error: Optional[str] = Field(
+        None, description="Set if this model could not be embedded/searched"
+    )
+
+
+class CompareResponse(BaseModel):
+    """Side-by-side comparison of several models over one query."""
+
+    query: str
+    models: List[CompareModelResults]
 
 
 class ReembedRequest(BaseModel):

--- a/apps/api/services/deriver.py
+++ b/apps/api/services/deriver.py
@@ -11,6 +11,7 @@ from apps.api import crud
 from apps.api.models.conversation import RawConversation
 from apps.api.ollama_client import ollama_client
 from apps.api.schemas.conversation import ConversationCreate, ConversationResponse
+from apps.api.services import settings_store
 from apps.api.services.classifier import infer_project, infer_topics
 from apps.api.services.pipelines import run_post_derivation
 
@@ -55,9 +56,10 @@ async def process_raw_conversation(
     # conversation_embeddings (keyed by provider/model), not the legacy
     # conversations.embedding column, so providers with different dimensions
     # can coexist.
-    provider = ollama_client.active_provider
-    model = ollama_client.active_model
-    embedding = await ollama_client.embed(text_content or " ")
+    provider, model = settings_store.get_active_embedding()
+    embedding = await ollama_client.embed(
+        text_content or " ", provider=provider, model=model
+    )
 
     project = infer_project(
         metadata=payload.metadata,

--- a/apps/api/services/settings_store.py
+++ b/apps/api/services/settings_store.py
@@ -54,6 +54,41 @@ def save_settings(payload: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def get_active_embedding() -> tuple[str, str]:
+    """Single source of truth for the active embedding ``(provider, model)``.
+
+    Reads the persisted settings store first; falls back to the env defaults
+    (``config.Settings``) as the initial seed when the store has no choice yet.
+    Every embedding decision point resolves through here so switching the model
+    (via ``PUT /api/embeddings/models/active`` or ``PUT /settings``) takes effect
+    without a restart and survives one.
+    """
+    from apps.api.config import get_settings  # lazy: avoid import cycle
+
+    data = load_settings()
+    settings = get_settings()
+    provider = (
+        data.get("embeddingProvider") or settings.EMBEDDING_PROVIDER or "ollama"
+    ).lower()
+    model = data.get("embeddingModel")
+    if not model:
+        model = (
+            settings.OPENAI_EMBEDDING_MODEL
+            if provider == "openai"
+            else settings.EMBEDDING_MODEL
+        )
+    return provider, model
+
+
+def set_active_embedding(provider: str, model: str) -> tuple[str, str]:
+    """Persist the active embedding ``(provider, model)`` to the settings store."""
+    data = load_settings()
+    data["embeddingProvider"] = provider
+    data["embeddingModel"] = model
+    save_settings(data)
+    return provider, model
+
+
 def get_repo_root(default: Optional[str] = None) -> Path:
     """Resolve repo root from settings or fallback."""
     data = load_settings()

--- a/compose.yml
+++ b/compose.yml
@@ -62,8 +62,8 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENAI_EMBEDDING_MODEL=${OPENAI_EMBEDDING_MODEL:-text-embedding-3-large}
       - OLLAMA_URL=${OLLAMA_URL:-http://ollama:11434}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-qwen3-embedding:8b}
-      - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-3072}
+      # Active embedding model is the settings store (SSoT), seeded by the API's
+      # bge-m3 default. Set EMBEDDING_MODEL only to override that initial seed.
       - DEBUG=${DEBUG:-true}
     depends_on:
       postgres:
@@ -108,7 +108,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-mindbase}:${POSTGRES_PASSWORD:-mindbase_dev}@postgres:${POSTGRES_INTERNAL_PORT:-5432}/${POSTGRES_DB:-mindbase_dev}
       - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-qwen3-embedding:8b}
+      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-bge-m3}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENAI_EMBEDDING_MODEL=${OPENAI_EMBEDDING_MODEL:-text-embedding-3-large}
       - LLM_MODEL=${LLM_MODEL:-gpt-4o}


### PR DESCRIPTION
## Why

Choosing the embedding model by **editing config files** is wrong — to validate/compare models you need to switch them at runtime, and the setting needs **one source of truth**. Today the active provider/model is split across three disconnected places:

1. `config.Settings` — env, `@lru_cache`d (boot-frozen)
2. `ollama_client` — in-memory, mutated by `PUT /api/embeddings/models/active` but **not persisted** (resets on restart)
3. `settings_store` (`settings.json`, the UI-editable store) — had **no embedding field**

…and the defaults had drifted: `bge-m3`/1024 (`.env.example`/`CLAUDE.md`) vs `qwen3-embedding:8b` (README/compose=3072/CI=4096).

The backend for switching/comparison mostly already existed (`GET/POST/PUT /api/embeddings/models*`, per-model vector coexistence in `conversation_embeddings`, `POST /conversations/reembed`, search-by-model). The gaps were just **persistence/SSoT** and **drift**.

## What

**Single source of truth** — `settings.json` (via `settings_store`):
- New `settings_store.get_active_embedding()` / `set_active_embedding()`; env (`config.Settings`, default `bge-m3`) only **seeds** it when unset.
- Every decision point resolves through it: deriver, search default, `PUT /api/embeddings/models/active` (now **persists**), `PUT /settings`, and `GET /api/embeddings/models` `current`. → a switch **persists across restart** and takes effect **without one**.
- `config.py`: `EMBEDDING_MODEL` defaults to `bge-m3`, `EMBEDDING_DIMENSIONS` to 1024 (no longer required env; the real dim is derived from the vector length).
- `AppSettings` gains `embeddingProvider` / `embeddingModel`.

**Drift removed**: compose/CI stop pinning `qwen3`/3072/4096; `.env.example` dims auto-derived; README brands `bge-m3` (switchable), not qwen3.

**Compare API** (backend enablement for the future comparison UI): `POST /conversations/compare` runs one query across several `(provider, model)` and returns per-model ranked results + scores, isolating per-model errors. Backfill coverage with `/conversations/reembed` first.

## Verified locally (no symlink; throwaway pg + host Ollama)

- `uv run pytest tests/` → **19 passed**; ruff + black clean.
- Switch → written to `settings.json` (one key) → **survives restart** (re-read in a fresh process); env only seeds a fresh store.
- `GET /settings` and `GET /api/embeddings/models` both reflect the store (not the env default).
- `POST /conversations/compare` → `bge-m3` returns a hit (similarity 0.77); an uninstalled model yields a clean per-model `error` instead of failing the whole call.

## Follow-up (out of scope)

- **UI dropdown + comparison view (frontend)** — pending the surface decision (React `apps/settings` vs Swift menubar). The backend is ready: `GET /api/embeddings/models` (options/install state), `PUT /models/active` (persisted switch), `POST /conversations/{reembed,compare}`.