### PR TITLE
feat(api): backend as brain — chat settings SSoT, conversation list/get, chat models

### DIFF
--- a/apps/api/api/routes/chat.py
+++ b/apps/api/api/routes/chat.py
@@ -1,0 +1,26 @@
+"""Chat (LLM) API endpoints.
+
+The backend owns chat orchestration (model selection, RAG, prompt assembly, LLM
+invocation, persistence) so clients can be thin renderers. Part A exposes the
+model list + active selection; POST /api/chat streaming lands in Part B.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from apps.api.ollama_client import ollama_client
+from apps.api.services import settings_store
+
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+@router.get("/models")
+async def list_chat_models():
+    """Installed Ollama models available for chat, plus the active one (SSoT)."""
+    try:
+        installed = await ollama_client.list_models()
+    except Exception as exc:  # pragma: no cover - surfaced via API response
+        raise HTTPException(status_code=500, detail=f"Failed to list models: {exc}")
+    return {
+        "current": settings_store.get_chat_settings()["model"],
+        "available": installed,
+    }

--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -2,8 +2,9 @@
 
 import logging
 from datetime import datetime
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.config import get_settings
@@ -17,6 +18,7 @@ from apps.api.schemas.conversation import (
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
+    ConversationSummary,
     ReembedRequest,
     ReembedResponse,
     SearchQuery,
@@ -55,6 +57,47 @@ def _format_result(row) -> SearchResult:
         raw_id=row.raw_id,
         created_at=row.created_at,
         content_preview=preview,
+    )
+
+
+@router.get("", response_model=list[ConversationSummary])
+async def list_conversations_endpoint(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    source: str | None = Query(None),
+    project: str | None = Query(None),
+):
+    """List derived conversations (newest first). Backend is the store-of-record,
+    so clients render this instead of keeping their own local copy."""
+    rows = await crud.list_conversations(
+        db, limit=limit, offset=offset, source=source, project=project
+    )
+    return [ConversationSummary.model_validate(row) for row in rows]
+
+
+@router.get("/{conversation_id}", response_model=ConversationResponse)
+async def get_conversation_endpoint(
+    conversation_id: UUID, db: AsyncSession = Depends(get_db)
+):
+    """Fetch a single conversation with its full content payload."""
+    row = await crud.get_conversation(db, conversation_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return ConversationResponse(
+        id=row.id,
+        raw_id=row.raw_id,
+        source=row.source,
+        source_conversation_id=row.source_conversation_id,
+        title=row.title,
+        content=row.content,
+        metadata=row.conv_metadata or {},
+        message_count=row.message_count,
+        project=row.project,
+        topics=row.topics or [],
+        workspace_path=row.workspace_path,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 

--- a/apps/api/api/routes/settings.py
+++ b/apps/api/api/routes/settings.py
@@ -8,17 +8,26 @@ from apps.api.services import settings_store
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
-def _with_active_embedding(data: dict) -> AppSettings:
-    """Render AppSettings, always reflecting the live active embedding (SSoT)."""
+def _render(data: dict) -> AppSettings:
+    """Render AppSettings, always reflecting the live SSoT (embedding + chat)."""
     provider, model = settings_store.get_active_embedding()
-    merged = {**data, "embeddingProvider": provider, "embeddingModel": model}
+    chat = settings_store.get_chat_settings()
+    merged = {
+        **data,
+        "embeddingProvider": provider,
+        "embeddingModel": model,
+        "chatModel": chat["model"],
+        "chatTemperature": chat["temperature"],
+        "chatMaxTokens": chat["maxTokens"],
+        "chatSystemPrompt": chat["systemPrompt"],
+    }
     return AppSettings(**merged)
 
 
 @router.get("", response_model=AppSettings)
 async def get_settings() -> AppSettings:
     try:
-        return _with_active_embedding(settings_store.load_settings())
+        return _render(settings_store.load_settings())
     except Exception as exc:
         raise HTTPException(
             status_code=500, detail=f"Invalid settings file: {exc}"
@@ -36,5 +45,27 @@ async def update_settings(payload: AppSettings) -> AppSettings:
         provider = payload.embeddingProvider or current[0]
         model = payload.embeddingModel or current[1]
         merged["embeddingProvider"], merged["embeddingModel"] = provider, model
+    # Chat selection persists through its single setter too.
+    if any(
+        v is not None
+        for v in (
+            payload.chatModel,
+            payload.chatTemperature,
+            payload.chatMaxTokens,
+            payload.chatSystemPrompt,
+        )
+    ):
+        chat = settings_store.set_chat_settings(
+            model=payload.chatModel,
+            temperature=payload.chatTemperature,
+            max_tokens=payload.chatMaxTokens,
+            system_prompt=payload.chatSystemPrompt,
+        )
+        merged.update(
+            chatModel=chat["model"],
+            chatTemperature=chat["temperature"],
+            chatMaxTokens=chat["maxTokens"],
+            chatSystemPrompt=chat["systemPrompt"],
+        )
     settings_store.save_settings(merged)
-    return _with_active_embedding(merged)
+    return _render(merged)

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -35,6 +35,16 @@ class Settings(BaseSettings):
     # (crud.column_for_dim). Kept only for the legacy conversations.embedding column.
     EMBEDDING_DIMENSIONS: int = 1024
 
+    # Chat (LLM) — seed defaults only. The live source of truth is the settings
+    # store (services/settings_store.get_chat_settings); these seed it when unset.
+    CHAT_MODEL: str = "qwen2.5:3b"
+    CHAT_TEMPERATURE: float = 0.7
+    CHAT_MAX_TOKENS: int = 2048
+    CHAT_SYSTEM_PROMPT: str = (
+        "You are MindBase, a helpful assistant with access to the user's past "
+        "conversations. Use the provided context when relevant."
+    )
+
     # Max characters of input text per embedding call. Embedding models have a
     # fixed context window (bge-m3: 8192 tokens) and error on overflow, so long
     # transcripts are head-truncated to this budget before embedding. ~8000

--- a/apps/api/crud/__init__.py
+++ b/apps/api/crud/__init__.py
@@ -3,6 +3,8 @@
 from apps.api.crud.conversation import (
     create_conversation_record,
     create_raw_conversation,
+    get_conversation,
+    list_conversations,
 )
 from apps.api.crud.search import search_conversations
 from apps.api.crud.embeddings import (
@@ -16,6 +18,8 @@ from apps.api.crud.embeddings import (
 __all__ = [
     "create_raw_conversation",
     "create_conversation_record",
+    "get_conversation",
+    "list_conversations",
     "search_conversations",
     "column_for_dim",
     "count_conversations_missing_embedding",

--- a/apps/api/crud/conversation.py
+++ b/apps/api/crud/conversation.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import List, Optional
+from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.models.conversation import Conversation, RawConversation
@@ -69,3 +71,32 @@ async def create_conversation_record(
     await db.flush()
     await db.refresh(db_conversation)
     return db_conversation
+
+
+async def list_conversations(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+    source: Optional[str] = None,
+    project: Optional[str] = None,
+) -> List[Conversation]:
+    """Return derived conversations, newest first (backend is the store-of-record)."""
+    stmt = select(Conversation).order_by(Conversation.created_at.desc())
+    if source:
+        stmt = stmt.where(Conversation.source == source)
+    if project:
+        stmt = stmt.where(Conversation.project == project)
+    stmt = stmt.limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_conversation(
+    db: AsyncSession, conversation_id: UUID
+) -> Optional[Conversation]:
+    """Fetch a single derived conversation by id (with its full content payload)."""
+    result = await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id)
+    )
+    return result.scalar_one_or_none()

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from apps.api.config import get_settings
 from apps.api.api.routes import (
+    chat,
     control,
     conversations,
     embeddings,
@@ -34,6 +35,7 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(conversations.router)
 app.include_router(embeddings.router)
+app.include_router(chat.router)
 app.include_router(settings_routes.router)
 app.include_router(control.router)
 

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -84,6 +84,23 @@ class ConversationResponse(BaseModel):
         from_attributes = True
 
 
+class ConversationSummary(BaseModel):
+    """Lightweight conversation row for list views (no full content payload)."""
+
+    id: UUID
+    source: str
+    title: Optional[str]
+    project: Optional[str]
+    topics: List[str] = Field(default_factory=list)
+    message_count: int
+    workspace_path: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class ConversationQueuedResponse(BaseModel):
     """Schema returned when derivation is queued."""
 
@@ -119,6 +136,14 @@ class AppSettings(BaseModel):
     embeddingModel: Optional[str] = Field(
         None, description="Active embedding model name (from the model catalog)"
     )
+    # Chat (LLM) selection — also a single source of truth, persisted here.
+    # Null means "unset": the API seeds these from env defaults on read.
+    chatModel: Optional[str] = Field(None, description="Active chat (LLM) model")
+    chatTemperature: Optional[float] = Field(
+        None, description="Chat sampling temperature"
+    )
+    chatMaxTokens: Optional[int] = Field(None, description="Chat max output tokens")
+    chatSystemPrompt: Optional[str] = Field(None, description="Chat system prompt")
     collectors: List[CollectorConfig] = Field(default_factory=list)
     pipelines: List[PipelineConfig] = Field(default_factory=list)
 

--- a/apps/api/services/settings_store.py
+++ b/apps/api/services/settings_store.py
@@ -89,6 +89,47 @@ def set_active_embedding(provider: str, model: str) -> tuple[str, str]:
     return provider, model
 
 
+def get_chat_settings() -> Dict[str, Any]:
+    """Single source of truth for chat (LLM) settings.
+
+    Reads the persisted settings store first; env (``config.Settings``) only seeds
+    each field when unset. Mirrors get_active_embedding so the chat client can be a
+    thin renderer that owns no domain state of its own.
+    """
+    from apps.api.config import get_settings  # lazy: avoid import cycle
+
+    data = load_settings()
+    s = get_settings()
+    temperature = data.get("chatTemperature")
+    return {
+        "model": data.get("chatModel") or s.CHAT_MODEL,
+        "temperature": temperature if temperature is not None else s.CHAT_TEMPERATURE,
+        "maxTokens": data.get("chatMaxTokens") or s.CHAT_MAX_TOKENS,
+        "systemPrompt": data.get("chatSystemPrompt") or s.CHAT_SYSTEM_PROMPT,
+    }
+
+
+def set_chat_settings(
+    *,
+    model: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    system_prompt: str | None = None,
+) -> Dict[str, Any]:
+    """Persist any provided chat settings to the store (others left unchanged)."""
+    data = load_settings()
+    if model is not None:
+        data["chatModel"] = model
+    if temperature is not None:
+        data["chatTemperature"] = temperature
+    if max_tokens is not None:
+        data["chatMaxTokens"] = max_tokens
+    if system_prompt is not None:
+        data["chatSystemPrompt"] = system_prompt
+    save_settings(data)
+    return get_chat_settings()
+
+
 def get_repo_root(default: Optional[str] = None) -> Path:
     """Resolve repo root from settings or fallback."""
     data = load_settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,6 +240,22 @@ def stub_ollama_requests(monkeypatch, test_settings: Settings):
     monkeypatch.setattr(ollama_client, "embed", fake_embed, raising=False)
     monkeypatch.setattr(ollama_client, "embed_batch", fake_embed_batch, raising=False)
 
+    async def fake_list_models():
+        return ["bge-m3", "qwen2.5:3b"]
+
+    monkeypatch.setattr(ollama_client, "list_models", fake_list_models, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def isolate_settings_store(tmp_path, monkeypatch):
+    """Point the settings store at a per-test temp file so tests never touch the
+    real ~/.config/mindbase/settings.json (the embedding/chat SSoT lives there)."""
+    from apps.api.services import settings_store
+
+    settings_store.override_settings_path(tmp_path / "settings.json")
+    yield
+    settings_store.override_settings_path(None)
+
 
 @pytest.fixture
 def sample_conversation_messages() -> list[dict[str, str]]:

--- a/tests/test_chat_and_conversations.py
+++ b/tests/test_chat_and_conversations.py
@@ -1,0 +1,59 @@
+"""Backend-as-brain: chat settings SSoT, conversation store-of-record, chat models."""
+
+
+async def test_chat_settings_are_single_source_of_truth(async_client):
+    # Default seed comes through GET /settings.
+    r = await async_client.get("/settings")
+    assert r.status_code == 200
+    assert r.json()["chatModel"]  # seeded from env default
+
+    # Switching via PUT /settings persists to the store...
+    r = await async_client.put("/settings", json={"chatModel": "llama3.1:8b"})
+    assert r.status_code == 200
+    assert r.json()["chatModel"] == "llama3.1:8b"
+
+    # ...and every reader reflects it (GET /settings and GET /api/chat/models).
+    assert (await async_client.get("/settings")).json()["chatModel"] == "llama3.1:8b"
+    assert (await async_client.get("/api/chat/models")).json()["current"] == "llama3.1:8b"
+
+
+async def test_chat_models_lists_installed(async_client):
+    r = await async_client.get("/api/chat/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] == ["bge-m3", "qwen2.5:3b"]  # from the stub
+    assert "current" in body
+
+
+async def test_conversations_list_and_get(async_client):
+    payload = {
+        "source": "claude-code",
+        "source_conversation_id": "thread-list-1",
+        "title": "store-of-record demo",
+        "content": {
+            "messages": [
+                {"role": "user", "content": "how do I rebalance a uniswap v3 position"}
+            ]
+        },
+    }
+    stored = await async_client.post("/conversations/store", json=payload)
+    assert stored.status_code == 200
+    conv_id = stored.json()["id"]
+
+    # Backend is the store-of-record: the conversation appears in the list.
+    listed = await async_client.get("/conversations")
+    assert listed.status_code == 200
+    rows = listed.json()
+    assert any(row["id"] == conv_id for row in rows)
+    assert any(row["title"] == "store-of-record demo" for row in rows)
+
+    # And can be fetched in full by id.
+    got = await async_client.get(f"/conversations/{conv_id}")
+    assert got.status_code == 200
+    assert got.json()["id"] == conv_id
+    assert "messages" in got.json()["content"]
+
+
+async def test_get_unknown_conversation_404(async_client):
+    r = await async_client.get("/conversations/00000000-0000-0000-0000-000000000000")
+    assert r.status_code == 404


### PR DESCRIPTION
## Why

First step of making the backend the **single brain** so the UI clients (Swift menubar, React web) become **thin renderers** — today each surface holds its own state/logic and diverges from the backend (the React app is a non-functional mockup; the Swift app keeps settings in `@AppStorage` and conversations in `UserDefaults`, and calls Ollama directly). This PR adds the read/state endpoints clients need so they can stop owning domain state.

## What

- **Chat (LLM) settings → single source of truth** in the settings store, mirroring the embedding-model SSoT: `get_chat_settings()` / `set_chat_settings()` (store → env seed), exposed and updated via `GET`/`PUT /settings`. `config.py` seeds `CHAT_MODEL`/`CHAT_TEMPERATURE`/`CHAT_MAX_TOKENS`/`CHAT_SYSTEM_PROMPT`. → the Swift client can later drop its `@AppStorage` chat settings.
- **Backend = conversation store-of-record**: `GET /conversations` (list, paginated) and `GET /conversations/{id}` (full payload), backed by `crud.list_conversations` / `get_conversation`. → clients stop keeping a local `UserDefaults` copy.
- **`GET /api/chat/models`**: installed Ollama models + the active one, so clients list via the backend instead of hitting Ollama's `/api/tags` directly.

## Verified

- `uv run pytest tests/` → **23 passed** (4 new); ruff + black clean.
- Tests isolate the settings store to a per-test temp path (autouse fixture) so they never touch the real `~/.config/mindbase/settings.json`.

## Next (separate PR)

- **`POST /api/chat` (SSE)** — move chat orchestration (RAG + prompt assembly + Ollama streaming + persist) into the backend, killing the duplicate `OllamaClient`s and client-side RAG.
- Then the thin clients: React `apps/settings` (delete the mockup), Swift menubar (route through the API), with OpenAPI as the shared contract.