### PR TITLE
feat(api): POST /api/chat — backend-owned chat orchestration (SSE)

### DIFF
--- a/apps/api/api/routes/chat.py
+++ b/apps/api/api/routes/chat.py
@@ -1,16 +1,27 @@
 """Chat (LLM) API endpoints.
 
-The backend owns chat orchestration (model selection, RAG, prompt assembly, LLM
-invocation, persistence) so clients can be thin renderers. Part A exposes the
-model list + active selection; POST /api/chat streaming lands in Part B.
+The backend owns chat orchestration — model selection (settings SSoT), RAG over the
+user's past conversations, prompt assembly, the Ollama call, and persistence — so
+clients stay thin: they POST a message and render the streamed reply.
 """
 
-from fastapi import APIRouter, HTTPException
+import json
+import logging
+from datetime import datetime
 
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api import crud
+from apps.api.database import get_db
 from apps.api.ollama_client import ollama_client
+from apps.api.schemas.conversation import ChatRequest, ConversationCreate
 from apps.api.services import settings_store
+from apps.api.services.deriver import process_raw_conversation
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
+logger = logging.getLogger(__name__)
 
 
 @router.get("/models")
@@ -24,3 +35,106 @@ async def list_chat_models():
         "current": settings_store.get_chat_settings()["model"],
         "available": installed,
     }
+
+
+def _rag_preview(content: dict) -> str:
+    messages = content.get("messages") if isinstance(content, dict) else None
+    if messages:
+        text = " ".join(str(m.get("content", "")) for m in messages)
+    else:
+        text = str(content)
+    return text[:200]
+
+
+async def _retrieve_context(
+    db: AsyncSession, message: str, limit: int, threshold: float
+) -> str:
+    """Embed the message with the active embedding and pull related past turns."""
+    if limit <= 0:
+        return ""
+    provider, model = settings_store.get_active_embedding()
+    query_embedding = await ollama_client.embed(message, provider=provider, model=model)
+    rows = await crud.search_conversation_embeddings(
+        db=db,
+        query_embedding=query_embedding,
+        provider=provider,
+        model=model,
+        limit=limit,
+        threshold=threshold,
+    )
+    if not rows:
+        return ""
+    blocks = [
+        f"- [{row.source}] {row.title or 'untitled'}: {_rag_preview(row.content)}"
+        for row in rows
+    ]
+    return "\n\nRelevant past conversations:\n" + "\n".join(blocks)
+
+
+async def _persist_turn(db: AsyncSession, message: str, reply: str, model: str) -> None:
+    """Store the completed chat turn as a conversation (backend store-of-record)."""
+    payload = ConversationCreate(
+        source="mindbase-chat",
+        title=message[:100],
+        content={
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": reply},
+            ]
+        },
+        metadata={"model": model, "app": "mindbase-chat"},
+    )
+    raw = await crud.create_raw_conversation(
+        db,
+        payload,
+        raw_payload=payload.model_dump(mode="json"),
+        raw_metadata=dict(payload.metadata or {}),
+        workspace_path=None,
+        captured_at=datetime.utcnow(),
+    )
+    await process_raw_conversation(db, raw)
+    await db.commit()
+
+
+@router.post("")
+async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)):
+    """Stream a chat reply (SSE). The backend does RAG + prompt + LLM + persist."""
+    chat_cfg = settings_store.get_chat_settings()
+    model = request.model or chat_cfg["model"]
+
+    try:
+        context = await _retrieve_context(
+            db, request.message, request.rag_limit, request.rag_threshold
+        )
+    except Exception:  # RAG is best-effort; never block the reply
+        logger.exception("chat RAG failed; continuing without context")
+        context = ""
+
+    messages = [{"role": "system", "content": chat_cfg["systemPrompt"] + context}]
+    messages += [{"role": m.role, "content": m.content} for m in request.history]
+    messages.append({"role": "user", "content": request.message})
+    options = {
+        "temperature": chat_cfg["temperature"],
+        "num_predict": chat_cfg["maxTokens"],
+    }
+
+    async def event_stream():
+        reply = ""
+        try:
+            async for delta in ollama_client.chat(
+                messages, model=model, options=options
+            ):
+                reply += delta
+                yield f"data: {json.dumps({'delta': delta})}\n\n"
+        except Exception as exc:  # pragma: no cover - surfaced as a stream event
+            logger.exception("chat stream failed")
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+            return
+        if request.store and reply:
+            try:
+                await _persist_turn(db, request.message, reply, model)
+            except Exception:
+                logger.exception("chat persist failed (turn not stored)")
+        yield f"data: {json.dumps({'done': True})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -11,8 +11,9 @@ Model management (pull, delete, list) is delegated to services/model_manager.py.
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Iterable, List, Tuple
+from typing import AsyncIterator, Iterable, List, Tuple
 
 import httpx
 
@@ -175,6 +176,36 @@ class EmbeddingClient:
         if prov == OLLAMA:
             return [await self._ollama_embed(text, mdl) for text in text_list]
         raise ValueError(f"Unknown embedding provider: {prov!r}")
+
+    async def chat(
+        self,
+        messages: List[dict],
+        model: str,
+        options: dict | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream an Ollama chat completion, yielding content deltas.
+
+        Chat orchestration (RAG, prompt assembly, persistence) lives in the API
+        route; this is just the transport so the LLM call stays on the server and
+        clients never talk to Ollama directly.
+        """
+        url = f"{self.ollama_url}/api/chat"
+        payload: dict = {"model": model, "messages": messages, "stream": True}
+        if options:
+            payload["options"] = options
+
+        async with httpx.AsyncClient(timeout=300.0) as client:
+            async with client.stream("POST", url, json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    delta = (data.get("message") or {}).get("content")
+                    if delta:
+                        yield delta
+                    if data.get("done"):
+                        break
 
     async def health_check(self) -> bool:
         """Return True if the active provider responds successfully."""

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -157,6 +157,26 @@ class CommandResult(BaseModel):
     stderr: str
 
 
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    """A chat turn. The backend resolves the model/params from the settings SSoT,
+    fetches RAG context, assembles the prompt, streams the LLM, and persists — so
+    the client just sends a message and renders the stream."""
+
+    message: str = Field(..., min_length=1, description="User message")
+    model: Optional[str] = Field(None, description="Override the active chat model")
+    history: List[ChatMessage] = Field(
+        default_factory=list, description="Prior turns in this session"
+    )
+    rag_limit: int = Field(3, ge=0, le=20, description="Past conversations to retrieve")
+    rag_threshold: float = Field(0.5, ge=0.0, le=1.0)
+    store: bool = Field(True, description="Persist this turn as a conversation")
+
+
 class SearchQuery(BaseModel):
     """Schema for semantic search query"""
 

--- a/supabase/migrations/20260624000000_chat_source.sql
+++ b/supabase/migrations/20260624000000_chat_source.sql
@@ -1,0 +1,9 @@
+-- Allow the in-app chat ("mindbase-chat") as a conversation source so chat turns
+-- streamed by POST /api/chat can be persisted as memory. Replaces the existing
+-- inline source CHECK constraint (auto-named conversations_source_check).
+ALTER TABLE conversations DROP CONSTRAINT IF EXISTS conversations_source_check;
+ALTER TABLE conversations ADD CONSTRAINT conversations_source_check
+    CHECK (source IN (
+        'claude-code', 'claude-desktop', 'chatgpt', 'cursor', 'windsurf',
+        'slack', 'email', 'google-docs', 'mindbase-chat'
+    ));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,12 @@ def stub_ollama_requests(monkeypatch, test_settings: Settings):
 
     monkeypatch.setattr(ollama_client, "list_models", fake_list_models, raising=False)
 
+    async def fake_chat(messages, model, options=None):
+        for token in ["Hello", ", ", "world", "!"]:
+            yield token
+
+    monkeypatch.setattr(ollama_client, "chat", fake_chat, raising=False)
+
 
 @pytest.fixture(autouse=True)
 def isolate_settings_store(tmp_path, monkeypatch):

--- a/tests/test_chat_and_conversations.py
+++ b/tests/test_chat_and_conversations.py
@@ -1,5 +1,53 @@
 """Backend-as-brain: chat settings SSoT, conversation store-of-record, chat models."""
 
+import json
+
+
+def _sse_deltas(body: str) -> list[str]:
+    out = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            evt = json.loads(line[6:])
+            if "delta" in evt:
+                out.append(evt["delta"])
+    return out
+
+
+async def test_chat_streams_reply_and_persists_turn(async_client):
+    # rag_limit=0 keeps it self-contained (no stored vectors needed).
+    r = await async_client.post(
+        "/api/chat", json={"message": "hi there", "rag_limit": 0}
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+
+    # The streamed deltas reconstruct the (stubbed) reply, and the stream is `done`.
+    assert "".join(_sse_deltas(r.text)) == "Hello, world!"
+    assert any(
+        json.loads(line[6:]).get("done")
+        for line in r.text.splitlines()
+        if line.startswith("data: ")
+    )
+
+    # The completed turn is persisted (store-of-record), source mindbase-chat.
+    listed = await async_client.get(
+        "/conversations", params={"source": "mindbase-chat"}
+    )
+    assert listed.status_code == 200
+    assert any(row["source"] == "mindbase-chat" for row in listed.json())
+
+
+async def test_chat_can_skip_persistence(async_client):
+    r = await async_client.post(
+        "/api/chat", json={"message": "no save", "rag_limit": 0, "store": False}
+    )
+    assert r.status_code == 200
+    assert "".join(_sse_deltas(r.text)) == "Hello, world!"
+    listed = await async_client.get(
+        "/conversations", params={"source": "mindbase-chat"}
+    )
+    assert listed.json() == []
+
 
 async def test_chat_settings_are_single_source_of_truth(async_client):
     # Default seed comes through GET /settings.


### PR DESCRIPTION
## Why

Part 2 of making the backend the brain. Today the Swift client calls Ollama **directly** (`/api/chat`) and assembles RAG context + the prompt itself — a duplicated `OllamaClient` and client-side logic that drifts. This moves the whole chat turn server-side so any client just **POSTs a message and renders the stream**.

## What

- **`POST /api/chat` (SSE)** — the backend orchestrates the turn:
  1. resolves the chat model/params from the settings **SSoT** (`get_chat_settings`),
  2. runs **RAG** over the user's past conversations (active embedding),
  3. assembles the prompt (system + context + history),
  4. **streams** the Ollama chat completion as `text/event-stream`,
  5. **persists** the completed turn as a conversation (store-of-record; `store=false` opts out).
- **`ollama_client.chat()`** — async streaming transport for Ollama `/api/chat` (NDJSON → content deltas).
- **Migration `20260624000000_chat_source.sql`** — allow `'mindbase-chat'` as a conversation source so chat turns can persist. The existing `conversations_source_check` blocked it, so the Swift client's chat `/store` calls were silently failing.

## Verified

- `uv run pytest tests/` → **25 passed** (stream reconstructs the reply + the turn is persisted as `mindbase-chat`; `store=false` skips persistence). ruff + black clean (apps/api).
- Migration applied to a fresh DB: `mindbase-chat` inserts OK, an unknown source still fails the check.
- `ollama_client.chat()` live-streams from host Ollama (`qwen2.5:3b`).

## Next

This completes **Stage 1 (backend = brain)**. Stages 2–3 (separate PRs): make the React `apps/settings` and Swift menubar **thin renderers** over these endpoints (delete the React mockup; route Swift through `/api/chat`, `/settings`, `GET /conversations`, dropping its direct-Ollama + `@AppStorage` + local `UserDefaults` store), with **OpenAPI** as the shared contract.