### PR TITLE
chore(compose): rename postgres container to mindbase-postgres-canon

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -32,7 +32,7 @@ services:
   # PostgreSQL 17 + pgvector
   postgres:
     image: pgvector/pgvector:pg17
-    container_name: mindbase-postgres-dev
+    container_name: mindbase-postgres-canon
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-mindbase}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mindbase_dev}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,11 +145,15 @@ importers:
         specifier: ^7.0.3
         version: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.20.6)
 
+  libs/embedding: {}
+
   libs/generators:
     dependencies:
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
+
+  libs/markdown: {}
 
   libs/processors:
     dependencies:


### PR DESCRIPTION
## Summary

- Renames `container_name: mindbase-postgres-dev` → `mindbase-postgres-canon` in `compose.yml` — aligns with the naming convention used by the backup script (`PG_CONTAINER` default) and the mindbase-collect hooks.
- Updates `pnpm-lock.yaml` to resolve the `libs/embedding` and `libs/markdown` empty-workspace drift.

## Files

- `compose.yml` — container_name change only (SUMMARY_MODEL not included; that is in `feat/mindbase-recall-summary`)
- `pnpm-lock.yaml` — lock drift fix

## Dependency order

This PR has no upstream dependencies and should merge first. `chore/mindbase-backup-script` references `mindbase-postgres-canon` as the default `PG_CONTAINER` and should merge after this.