### PR TITLE
fix(migrations): idempotent ADD CONSTRAINT and fix ILIKE ANY / %% syntax

### DIFF
--- a/supabase/migrations/00000000000000_plain_pg_auth_shim.sql
+++ b/supabase/migrations/00000000000000_plain_pg_auth_shim.sql
@@ -1,0 +1,28 @@
+-- Plain-Postgres compatibility shim (runs first by filename sort order).
+--
+-- The initial schema migration declares RLS policies that call auth.role(),
+-- a Supabase built-in. On a vanilla postgres / pgvector image the auth schema
+-- and function do not exist, so CREATE POLICY aborts and the whole init stops
+-- with: ERROR: schema "auth" does not exist.
+--
+-- Create a permissive stub ONLY when it is absent. On real Supabase the native
+-- auth.role() already exists, so the DO block is a no-op and native auth is
+-- left untouched. This is a single-user local store, so a constant
+-- 'service_role' is the correct effective behavior.
+CREATE SCHEMA IF NOT EXISTS auth;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'auth' AND p.proname = 'role'
+  ) THEN
+    CREATE FUNCTION auth.role()
+      RETURNS text
+      LANGUAGE sql
+      STABLE
+    AS $fn$ SELECT 'service_role'::text $fn$;
+  END IF;
+END $$;

--- a/supabase/migrations/20241217130000_analysis_triggers.sql
+++ b/supabase/migrations/20241217130000_analysis_triggers.sql
@@ -121,7 +121,7 @@ BEGIN
         AND NEW.completion_percentage < 60 
         AND (last_synthesis IS NULL OR last_synthesis < NOW() - INTERVAL '24 hours') THEN
         
-        RAISE NOTICE 'Section % may benefit from synthesis (% patterns available, %% complete)', 
+        RAISE NOTICE 'Section % may benefit from synthesis (% patterns available, % percent complete)',
             NEW.title, pattern_count, NEW.completion_percentage;
     END IF;
     
@@ -347,9 +347,11 @@ SELECT
     AVG(tp.confidence_score) as avg_pattern_confidence,
     bs.updated_at as last_updated
 FROM book_structure bs
+-- "x ILIKE '%' || ANY(arr) || '%'" is not valid SQL. Match the title against any
+-- theme/keyword substring via unnest+EXISTS.
 LEFT JOIN thought_patterns tp ON (
-    bs.title ILIKE '%' || ANY(tp.themes) || '%'
-    OR bs.title ILIKE '%' || ANY(tp.keywords) || '%'
+    EXISTS (SELECT 1 FROM unnest(tp.themes) AS t WHERE bs.title ILIKE '%' || t || '%')
+    OR EXISTS (SELECT 1 FROM unnest(tp.keywords) AS k WHERE bs.title ILIKE '%' || k || '%')
 )
 WHERE bs.level > 1 
     AND bs.completion_percentage < 80

--- a/supabase/migrations/20250202093000_raw_conversations.sql
+++ b/supabase/migrations/20250202093000_raw_conversations.sql
@@ -22,9 +22,17 @@ ALTER TABLE conversations
     ADD COLUMN IF NOT EXISTS raw_id UUID,
     ADD COLUMN IF NOT EXISTS workspace_path TEXT;
 
-ALTER TABLE conversations
-    ADD CONSTRAINT IF NOT EXISTS fk_conversations_raw
+-- Postgres has no "ADD CONSTRAINT IF NOT EXISTS"; guard it so re-runs are idempotent.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_conversations_raw'
+  ) THEN
+    ALTER TABLE conversations
+      ADD CONSTRAINT fk_conversations_raw
         FOREIGN KEY (raw_id) REFERENCES raw_conversations(id) ON DELETE SET NULL;
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_conversations_workspace_path
     ON conversations(workspace_path);


### PR DESCRIPTION
## Summary

Three migration fixes for vanilla-Postgres re-run safety and SQL correctness.

- `00000000000000_plain_pg_auth_shim.sql` (new) — creates a stub `auth.role()` only when absent, so plain pgvector images can run the init chain without hitting "schema auth does not exist".
- `20241217130000_analysis_triggers.sql` — fixes `%%` → `% percent` in RAISE NOTICE (literal `%%` is only needed in `format()`/`EXECUTE`, not in `RAISE`), and rewrites `ILIKE '%' || ANY(arr) || '%'` to `EXISTS+unnest` (the ANY form is not valid SQL).
- `20250202093000_raw_conversations.sql` — wraps `ADD CONSTRAINT fk_conversations_raw` in a `DO $$ IF NOT EXISTS pg_constraint $$` guard because Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, making re-runs idempotent.

## Files

- `supabase/migrations/00000000000000_plain_pg_auth_shim.sql` (new)
- `supabase/migrations/20241217130000_analysis_triggers.sql` (modified)
- `supabase/migrations/20250202093000_raw_conversations.sql` (modified)

## Dependency order

No upstream dependencies. Independent of the other PRs in this batch.