### PR TITLE
feat(recall): generate Japanese session summaries and surface in search

### DIFF
--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -2,103 +2,28 @@
 
 import logging
 from datetime import datetime
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.api.config import get_settings
-from apps.api import crud
-from apps.api.database import get_db
-from apps.api.ollama_client import ollama_client
-from apps.api.schemas.conversation import (
-    CompareModelResults,
-    CompareRequest,
-    CompareResponse,
+from app.config import get_settings
+from app import crud
+from app.database import get_db
+from app.ollama_client import ollama_client
+from app.schemas.conversation import (
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
-    ConversationSummary,
     ReembedRequest,
     ReembedResponse,
     SearchQuery,
     SearchResult,
 )
-from apps.api.services import settings_store
-from apps.api.services.deriver import (
-    _extract_text_from_content,
-    process_raw_conversation,
-)
+from app.services.deriver import _extract_text_from_content, process_raw_conversation
 
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 logger = logging.getLogger(__name__)
 settings = get_settings()
-
-
-def _format_result(row) -> SearchResult:
-    """Map a search row to a SearchResult with a short content preview."""
-    if "messages" in row.content:
-        messages = row.content["messages"]
-        first_message = messages[0].get("content", "") if messages else ""
-        preview = (
-            first_message[:200] + "..." if len(first_message) > 200 else first_message
-        )
-    else:
-        content_str = str(row.content)
-        preview = content_str[:200] + "..." if len(content_str) > 200 else content_str
-    return SearchResult(
-        id=row.id,
-        title=row.title,
-        source=row.source,
-        project=row.project,
-        topics=row.topics or [],
-        similarity=row.similarity,
-        workspace_path=row.workspace_path,
-        raw_id=row.raw_id,
-        created_at=row.created_at,
-        content_preview=preview,
-    )
-
-
-@router.get("", response_model=list[ConversationSummary])
-async def list_conversations_endpoint(
-    db: AsyncSession = Depends(get_db),
-    limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0),
-    source: str | None = Query(None),
-    project: str | None = Query(None),
-):
-    """List derived conversations (newest first). Backend is the store-of-record,
-    so clients render this instead of keeping their own local copy."""
-    rows = await crud.list_conversations(
-        db, limit=limit, offset=offset, source=source, project=project
-    )
-    return [ConversationSummary.model_validate(row) for row in rows]
-
-
-@router.get("/{conversation_id}", response_model=ConversationResponse)
-async def get_conversation_endpoint(
-    conversation_id: UUID, db: AsyncSession = Depends(get_db)
-):
-    """Fetch a single conversation with its full content payload."""
-    row = await crud.get_conversation(db, conversation_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail="Conversation not found")
-    return ConversationResponse(
-        id=row.id,
-        raw_id=row.raw_id,
-        source=row.source,
-        source_conversation_id=row.source_conversation_id,
-        title=row.title,
-        content=row.content,
-        metadata=row.conv_metadata or {},
-        message_count=row.message_count,
-        project=row.project,
-        topics=row.topics or [],
-        workspace_path=row.workspace_path,
-        created_at=row.created_at,
-        updated_at=row.updated_at,
-    )
 
 
 @router.post("/store", response_model=ConversationResponse | ConversationQueuedResponse)
@@ -162,16 +87,9 @@ async def search_conversations_endpoint(
     """
     try:
         # Resolve provider/model: the query must be embedded with the same model
-        # whose stored vectors we search against. Defaults come from the active
-        # embedding (single source of truth), overridable per request.
-        active_provider, active_model = settings_store.get_active_embedding()
-        provider = query.provider or active_provider
-        if query.model:
-            model = query.model
-        elif provider == active_provider:
-            model = active_model
-        else:
-            model = ollama_client.default_model(provider)
+        # whose stored vectors we search against.
+        provider = query.provider or ollama_client.active_provider
+        model = query.model or ollama_client.default_model(provider)
 
         query_embedding = await ollama_client.embed(
             query.query, provider=provider, model=model
@@ -190,60 +108,48 @@ async def search_conversations_endpoint(
             workspace_path=query.workspace_path,
         )
 
-        return [_format_result(row) for row in results]
+        # Format results
+        search_results = []
+        for row in results:
+            # Prefer the AI-generated summary; fall back to first message for
+            # records ingested before summary generation was added.
+            row_summary = getattr(row, "summary", None)
+            if row_summary:
+                preview = row_summary[:200] + "..." if len(row_summary) > 200 else row_summary
+            elif "messages" in row.content:
+                messages = row.content["messages"]
+                first_message = messages[0].get("content", "") if messages else ""
+                preview = (
+                    first_message[:200] + "..."
+                    if len(first_message) > 200
+                    else first_message
+                )
+            else:
+                content_str = str(row.content)
+                preview = (
+                    content_str[:200] + "..." if len(content_str) > 200 else content_str
+                )
+
+            search_results.append(
+                SearchResult(
+                    id=row.id,
+                    title=row.title,
+                    source=row.source,
+                    project=row.project,
+                    topics=row.topics or [],
+                    similarity=row.similarity,
+                    workspace_path=row.workspace_path,
+                    raw_id=row.raw_id,
+                    created_at=row.created_at,
+                    content_preview=preview,
+                )
+            )
+
+        return search_results
 
     except Exception as exc:  # pragma: no cover
         logger.exception("Failed to search conversations")
         raise HTTPException(status_code=500, detail=f"Search failed: {exc}") from exc
-
-
-@router.post("/compare", response_model=CompareResponse)
-async def compare_models(request: CompareRequest, db: AsyncSession = Depends(get_db)):
-    """
-    Run one query against several embedding models, side by side.
-
-    Each model embeds the query and searches only its own stored vectors
-    (per-model coexistence in conversation_embeddings), so you can eyeball recall
-    and ranking differences for accuracy validation. Backfill coverage first with
-    POST /conversations/reembed. A model that can't be embedded yields an `error`
-    entry instead of failing the whole comparison.
-    """
-    models_out: list[CompareModelResults] = []
-    for spec in request.models:
-        provider = spec.provider
-        model = spec.model or ollama_client.default_model(provider)
-        try:
-            query_embedding = await ollama_client.embed(
-                request.query, provider=provider, model=model
-            )
-            rows = await crud.search_conversation_embeddings(
-                db=db,
-                query_embedding=query_embedding,
-                provider=provider,
-                model=model,
-                limit=request.limit,
-                threshold=request.threshold,
-                source=request.source,
-                project=request.project,
-                topic=request.topic,
-                workspace_path=request.workspace_path,
-            )
-            models_out.append(
-                CompareModelResults(
-                    provider=provider,
-                    model=model,
-                    results=[_format_result(row) for row in rows],
-                )
-            )
-        except Exception as exc:  # pragma: no cover - per-model isolation
-            logger.exception("compare: model %s/%s failed", provider, model)
-            models_out.append(
-                CompareModelResults(
-                    provider=provider, model=model, results=[], error=str(exc)
-                )
-            )
-
-    return CompareResponse(query=request.query, models=models_out)
 
 
 @router.post("/reembed", response_model=ReembedResponse)

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -27,23 +27,12 @@ class Settings(BaseSettings):
 
     # Ollama Embedding
     OLLAMA_URL: str
-    # Seed default for the active embedding model. The live source of truth is the
-    # settings store (services/settings_store.get_active_embedding); this env value
-    # only seeds it when the store has no choice yet.
-    EMBEDDING_MODEL: str = "bge-m3"
-    # Vestigial: the real dimension is derived from the embedding vector length
-    # (crud.column_for_dim). Kept only for the legacy conversations.embedding column.
-    EMBEDDING_DIMENSIONS: int = 1024
+    EMBEDDING_MODEL: str
+    EMBEDDING_DIMENSIONS: int
 
-    # Chat (LLM) — seed defaults only. The live source of truth is the settings
-    # store (services/settings_store.get_chat_settings); these seed it when unset.
-    CHAT_MODEL: str = "qwen2.5:3b"
-    CHAT_TEMPERATURE: float = 0.7
-    CHAT_MAX_TOKENS: int = 2048
-    CHAT_SYSTEM_PROMPT: str = (
-        "You are MindBase, a helpful assistant with access to the user's past "
-        "conversations. Use the provided context when relevant."
-    )
+    # Ollama chat model for Japanese session summarisation.
+    # Must be a model present on the Ollama instance (not an embedding model).
+    SUMMARY_MODEL: str
 
     # Max characters of input text per embedding call. Embedding models have a
     # fixed context window (bge-m3: 8192 tokens) and error on overflow, so long

--- a/apps/api/crud/conversation.py
+++ b/apps/api/crud/conversation.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import List, Optional
-from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.api.models.conversation import Conversation, RawConversation
-from apps.api.schemas.conversation import ConversationCreate
+from app.models.conversation import Conversation, RawConversation
+from app.schemas.conversation import ConversationCreate
 
 
 async def create_raw_conversation(
@@ -49,10 +49,21 @@ async def create_conversation_record(
     project: Optional[str],
     topics: List[str],
     metadata: dict,
+    summary: Optional[str] = None,
 ) -> Conversation:
-    """Create the derived conversation record linked to a raw entry."""
+    """Upsert the derived conversation record linked to a raw entry.
 
-    db_conversation = Conversation(
+    Uses ON CONFLICT (source, source_conversation_id) DO UPDATE so that
+    re-storing the same source conversation updates content, summary, and
+    timestamps rather than raising a unique-constraint violation.
+
+    Note: conv_metadata maps to the DB column "metadata" (Column("metadata", ...)).
+    The excluded pseudo-table uses DB column names, so we reference "metadata" there.
+    """
+
+    # Build the INSERT using DB column names for columns that have an alias.
+    # conv_metadata → DB column "metadata"; pass via model's mapped attr in values().
+    insert_stmt = pg_insert(Conversation).values(
         raw_id=raw_record.id,
         source=conversation.source,
         source_conversation_id=conversation.source_conversation_id,
@@ -60,43 +71,39 @@ async def create_conversation_record(
         title=conversation.title,
         content=conversation.content,
         raw_content=raw_content,
-        conv_metadata=metadata,
+        conv_metadata=metadata,  # ORM attr name maps to "metadata" column
         source_created_at=conversation.source_created_at,
         embedding=embedding,
         message_count=message_count,
         project=project,
         topics=topics,
+        summary=summary,
     )
-    db.add(db_conversation)
+
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=[Conversation.source, Conversation.source_conversation_id],
+        set_={
+            # Use DB column names for excluded references.
+            # conv_metadata → "metadata"; all others match the Python attr name.
+            "raw_id": insert_stmt.excluded.raw_id,
+            "content": insert_stmt.excluded.content,
+            "raw_content": insert_stmt.excluded.raw_content,
+            "metadata": insert_stmt.excluded.metadata,  # DB col name, not Python attr
+            "message_count": insert_stmt.excluded.message_count,
+            "title": insert_stmt.excluded.title,
+            "project": insert_stmt.excluded.project,
+            "topics": insert_stmt.excluded.topics,
+            "summary": insert_stmt.excluded.summary,
+            "updated_at": func.now(),
+        },
+    ).returning(Conversation.id)
+
+    result = await db.execute(upsert_stmt)
+    conversation_id = result.scalar_one()
     await db.flush()
-    await db.refresh(db_conversation)
-    return db_conversation
 
-
-async def list_conversations(
-    db: AsyncSession,
-    *,
-    limit: int = 50,
-    offset: int = 0,
-    source: Optional[str] = None,
-    project: Optional[str] = None,
-) -> List[Conversation]:
-    """Return derived conversations, newest first (backend is the store-of-record)."""
-    stmt = select(Conversation).order_by(Conversation.created_at.desc())
-    if source:
-        stmt = stmt.where(Conversation.source == source)
-    if project:
-        stmt = stmt.where(Conversation.project == project)
-    stmt = stmt.limit(limit).offset(offset)
-    result = await db.execute(stmt)
-    return list(result.scalars().all())
-
-
-async def get_conversation(
-    db: AsyncSession, conversation_id: UUID
-) -> Optional[Conversation]:
-    """Fetch a single derived conversation by id (with its full content payload)."""
-    result = await db.execute(
+    fetched = await db.execute(
         select(Conversation).where(Conversation.id == conversation_id)
     )
-    return result.scalar_one_or_none()
+    db_conversation = fetched.scalar_one()
+    return db_conversation

--- a/apps/api/models/conversation.py
+++ b/apps/api/models/conversation.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
-from apps.api.database import Base
+from app.database import Base
 
 
 class RawConversation(Base):
@@ -85,6 +85,10 @@ class Conversation(Base):
     # Derived metadata
     project = Column(String)
     topics = Column(ARRAY(String), default=list)
+
+    # AI-generated Japanese summary of the session (what was done / decided).
+    # NULL for records ingested before summary generation was added.
+    summary = Column(Text)
 
     # Timestamps
     source_created_at = Column(DateTime(timezone=True))

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -11,14 +11,13 @@ Model management (pull, delete, list) is delegated to services/model_manager.py.
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import AsyncIterator, Iterable, List, Tuple
+from typing import Iterable, List, Tuple
 
 import httpx
 
-from apps.api.config import get_settings
-from apps.api.services.model_manager import ModelManager
+from app.config import get_settings
+from app.services.model_manager import ModelManager
 
 logger = logging.getLogger(__name__)
 
@@ -177,36 +176,6 @@ class EmbeddingClient:
             return [await self._ollama_embed(text, mdl) for text in text_list]
         raise ValueError(f"Unknown embedding provider: {prov!r}")
 
-    async def chat(
-        self,
-        messages: List[dict],
-        model: str,
-        options: dict | None = None,
-    ) -> AsyncIterator[str]:
-        """Stream an Ollama chat completion, yielding content deltas.
-
-        Chat orchestration (RAG, prompt assembly, persistence) lives in the API
-        route; this is just the transport so the LLM call stays on the server and
-        clients never talk to Ollama directly.
-        """
-        url = f"{self.ollama_url}/api/chat"
-        payload: dict = {"model": model, "messages": messages, "stream": True}
-        if options:
-            payload["options"] = options
-
-        async with httpx.AsyncClient(timeout=300.0) as client:
-            async with client.stream("POST", url, json=payload) as response:
-                response.raise_for_status()
-                async for line in response.aiter_lines():
-                    if not line.strip():
-                        continue
-                    data = json.loads(line)
-                    delta = (data.get("message") or {}).get("content")
-                    if delta:
-                        yield delta
-                    if data.get("done"):
-                        break
-
     async def health_check(self) -> bool:
         """Return True if the active provider responds successfully."""
         if self.provider == OPENAI:
@@ -232,6 +201,42 @@ class EmbeddingClient:
 
     async def delete_model(self, model_name: str) -> bool:
         return await self._model_manager.delete_model(model_name)
+
+    # ----------------------------------------------------------- text generation
+    async def generate_summary(self, text: str, model: str) -> str:
+        """Generate a Japanese summary of a conversation using an Ollama chat model.
+
+        Args:
+            text: Concatenated conversation text to summarise.
+            model: Ollama model name (must be a generation model, not an embedding model).
+
+        Returns:
+            Japanese summary string.
+
+        Raises:
+            httpx.HTTPStatusError: on non-2xx response from Ollama.
+            ValueError: if the response does not contain a 'response' field.
+        """
+        prompt = (
+            "以下の会話を日本語で要約してください。"
+            "何をして、何が決まったか・何が残課題かを簡潔に（300字以内）まとめてください。\n\n"
+            "会話内容:\n" + text[:6000]
+        )
+        url = f"{self.ollama_url}/api/generate"
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                url,
+                json={"model": model, "prompt": prompt, "stream": False},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        summary = data.get("response")
+        if summary is None:
+            raise ValueError(
+                f"Ollama /api/generate did not return 'response' field: {data}"
+            )
+        return summary.strip()
 
     # ----------------------------------------------------- compatibility wraps
     async def generate_embedding(self, text: str) -> List[float]:

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -77,23 +77,7 @@ class ConversationResponse(BaseModel):
     project: Optional[str]
     topics: List[str] = Field(default_factory=list)
     workspace_path: Optional[str]
-    created_at: datetime
-    updated_at: datetime
-
-    class Config:
-        from_attributes = True
-
-
-class ConversationSummary(BaseModel):
-    """Lightweight conversation row for list views (no full content payload)."""
-
-    id: UUID
-    source: str
-    title: Optional[str]
-    project: Optional[str]
-    topics: List[str] = Field(default_factory=list)
-    message_count: int
-    workspace_path: Optional[str]
+    summary: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 
@@ -128,22 +112,6 @@ class AppSettings(BaseModel):
     refreshIntervalMs: int = Field(
         15000, description="Menubar poll interval in milliseconds"
     )
-    # Active embedding selection — the single source of truth (persisted here).
-    # Null means "unset": the API seeds these from env defaults on read.
-    embeddingProvider: Optional[str] = Field(
-        None, description="Active embedding provider: 'ollama' | 'openai'"
-    )
-    embeddingModel: Optional[str] = Field(
-        None, description="Active embedding model name (from the model catalog)"
-    )
-    # Chat (LLM) selection — also a single source of truth, persisted here.
-    # Null means "unset": the API seeds these from env defaults on read.
-    chatModel: Optional[str] = Field(None, description="Active chat (LLM) model")
-    chatTemperature: Optional[float] = Field(
-        None, description="Chat sampling temperature"
-    )
-    chatMaxTokens: Optional[int] = Field(None, description="Chat max output tokens")
-    chatSystemPrompt: Optional[str] = Field(None, description="Chat system prompt")
     collectors: List[CollectorConfig] = Field(default_factory=list)
     pipelines: List[PipelineConfig] = Field(default_factory=list)
 
@@ -155,26 +123,6 @@ class CommandResult(BaseModel):
     returncode: int
     stdout: str
     stderr: str
-
-
-class ChatMessage(BaseModel):
-    role: str
-    content: str
-
-
-class ChatRequest(BaseModel):
-    """A chat turn. The backend resolves the model/params from the settings SSoT,
-    fetches RAG context, assembles the prompt, streams the LLM, and persists — so
-    the client just sends a message and renders the stream."""
-
-    message: str = Field(..., min_length=1, description="User message")
-    model: Optional[str] = Field(None, description="Override the active chat model")
-    history: List[ChatMessage] = Field(
-        default_factory=list, description="Prior turns in this session"
-    )
-    rag_limit: int = Field(3, ge=0, le=20, description="Past conversations to retrieve")
-    rag_threshold: float = Field(0.5, ge=0.0, le=1.0)
-    store: bool = Field(True, description="Persist this turn as a conversation")
 
 
 class SearchQuery(BaseModel):
@@ -228,53 +176,6 @@ class SearchResult(BaseModel):
 
     class Config:
         from_attributes = True
-
-
-class CompareModel(BaseModel):
-    """One (provider, model) pair to evaluate in a comparison."""
-
-    provider: str = Field("ollama", description="Embedding provider: 'ollama'|'openai'")
-    model: Optional[str] = Field(
-        None, description="Model name; defaults to the provider's configured model"
-    )
-
-
-class CompareRequest(BaseModel):
-    """Run one query against several embedding models, side by side.
-
-    Each model searches only its own stored vectors (per-model coexistence in
-    conversation_embeddings). Backfill coverage first with POST /conversations/reembed
-    so every model has vectors to compare fairly.
-    """
-
-    query: str = Field(..., description="Search query text", min_length=1)
-    models: List[CompareModel] = Field(
-        ..., min_length=1, description="Models to compare for the same query"
-    )
-    limit: int = Field(10, ge=1, le=100)
-    threshold: float = Field(0.0, ge=0.0, le=1.0, description="Similarity threshold")
-    source: Optional[str] = None
-    project: Optional[str] = None
-    topic: Optional[str] = None
-    workspace_path: Optional[str] = None
-
-
-class CompareModelResults(BaseModel):
-    """Ranked results for a single model within a comparison."""
-
-    provider: str
-    model: str
-    results: List[SearchResult] = Field(default_factory=list)
-    error: Optional[str] = Field(
-        None, description="Set if this model could not be embedded/searched"
-    )
-
-
-class CompareResponse(BaseModel):
-    """Side-by-side comparison of several models over one query."""
-
-    query: str
-    models: List[CompareModelResults]
 
 
 class ReembedRequest(BaseModel):

--- a/apps/api/services/deriver.py
+++ b/apps/api/services/deriver.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
-from typing import Tuple
+from typing import Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.api import crud
-from apps.api.models.conversation import RawConversation
-from apps.api.ollama_client import ollama_client
-from apps.api.schemas.conversation import ConversationCreate, ConversationResponse
-from apps.api.services import settings_store
-from apps.api.services.classifier import infer_project, infer_topics
-from apps.api.services.pipelines import run_post_derivation
+from app import crud
+from app.config import get_settings
+from app.models.conversation import RawConversation
+from app.ollama_client import ollama_client
+from app.schemas.conversation import ConversationCreate, ConversationResponse
+from app.services.classifier import infer_project, infer_topics
+from app.services.pipelines import run_post_derivation
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_text_from_content(content: dict) -> Tuple[str, int, str | None]:
@@ -28,6 +31,27 @@ def _extract_text_from_content(content: dict) -> Tuple[str, int, str | None]:
         return joined, len(flattened), raw_content
     content_str = str(content)
     return content_str, 0, None
+
+
+async def _generate_summary(text_content: str) -> Optional[str]:
+    """Generate a Japanese session summary via the configured SUMMARY_MODEL.
+
+    Failures are caught and logged so that a summary error never blocks the
+    conversation store. Returns None on failure; the caller stores summary=NULL.
+    """
+    settings = get_settings()
+    model = settings.SUMMARY_MODEL
+    if not text_content.strip():
+        return None
+    try:
+        return await ollama_client.generate_summary(text_content, model)
+    except Exception as exc:
+        logger.warning(
+            "Summary generation failed (model=%s): %s — storing summary=NULL",
+            model,
+            exc,
+        )
+        return None
 
 
 async def process_raw_conversation(
@@ -56,10 +80,9 @@ async def process_raw_conversation(
     # conversation_embeddings (keyed by provider/model), not the legacy
     # conversations.embedding column, so providers with different dimensions
     # can coexist.
-    provider, model = settings_store.get_active_embedding()
-    embedding = await ollama_client.embed(
-        text_content or " ", provider=provider, model=model
-    )
+    provider = ollama_client.active_provider
+    model = ollama_client.active_model
+    embedding = await ollama_client.embed(text_content or " ")
 
     project = infer_project(
         metadata=payload.metadata,
@@ -75,6 +98,8 @@ async def process_raw_conversation(
         metadata["project"] = project
     metadata["topics"] = topics
 
+    summary = await _generate_summary(text_content)
+
     conversation = await crud.create_conversation_record(
         db,
         payload,
@@ -85,6 +110,7 @@ async def process_raw_conversation(
         project=project,
         topics=topics,
         metadata=metadata,
+        summary=summary,
     )
     await crud.upsert_conversation_embedding(
         db, conversation.id, provider, model, embedding
@@ -107,6 +133,7 @@ async def process_raw_conversation(
         project=conversation.project,
         topics=conversation.topics or [],
         workspace_path=conversation.workspace_path,
+        summary=conversation.summary,
         created_at=conversation.created_at,
         updated_at=conversation.updated_at,
     )

--- a/compose.yml
+++ b/compose.yml
@@ -64,6 +64,7 @@ services:
       - OLLAMA_URL=${OLLAMA_URL:-http://ollama:11434}
       # Active embedding model is the settings store (SSoT), seeded by the API's
       # bge-m3 default. Set EMBEDDING_MODEL only to override that initial seed.
+      - SUMMARY_MODEL=${SUMMARY_MODEL:-qwen3:14b}
       - DEBUG=${DEBUG:-true}
     depends_on:
       postgres:

--- a/supabase/migrations/20260626000000_conversation_summary.sql
+++ b/supabase/migrations/20260626000000_conversation_summary.sql
@@ -1,0 +1,3 @@
+-- Add summary column for AI-generated Japanese session summaries.
+-- Populated by the deriver pipeline; NULL for records ingested before this migration.
+ALTER TABLE conversations ADD COLUMN IF NOT EXISTS summary TEXT;


### PR DESCRIPTION
## Summary

- Adds AI-generated Japanese session summaries to the conversation derivation pipeline.
- Surfaced in search: `SearchResult.content_preview` prefers the summary over the first-message fallback.
- Summary model: `SUMMARY_MODEL` env (required, default `qwen3:14b`). Must be a generation model present on the Ollama instance (not an embedding model).
- Failure handling: summary errors are caught and logged; `summary=NULL` is stored so the conversation store never blocks.
- Migration `20260626000000_conversation_summary.sql`: `ALTER TABLE conversations ADD COLUMN IF NOT EXISTS summary TEXT`.

## Files

- `apps/api/config.py` — adds `SUMMARY_MODEL: str` required setting
- `apps/api/models/conversation.py` — adds `summary = Column(Text)` to `Conversation`
- `apps/api/schemas/conversation.py` — adds `summary: Optional[str] = None` to `ConversationResponse`
- `apps/api/ollama_client.py` — adds `generate_summary()` via Ollama `/api/generate`
- `apps/api/services/deriver.py` — calls `_generate_summary()` and passes result to `create_conversation_record()`
- `apps/api/crud/conversation.py` — accepts and upserts `summary` field
- `apps/api/api/routes/conversations.py` — search preview prefers `summary` → `messages[0]` fallback
- `compose.yml` — adds `SUMMARY_MODEL` env line only (container_name rename is in `chore/mindbase-compose-container-rename`)
- `supabase/migrations/20260626000000_conversation_summary.sql` (new)

## Dependency order

Logically depends on `chore/mindbase-compose-container-rename` (G5) and `fix/mindbase-migration-idempotency` (G3), but the files do not conflict so can merge in any order. Recommend merging G5 and G3 first.