### PR TITLE
feat(collectors): add Local Agent Mode and Cursor cursorDiskKV collection

### DIFF
--- a/libs/collectors/claude_collector.py
+++ b/libs/collectors/claude_collector.py
@@ -40,7 +40,8 @@ class ClaudeDesktopCollector(BaseCollector):
                     # Local Agent Mode keeps full transcripts as audit.jsonl per
                     # session (the IndexedDB/Local Storage paths above only hold a
                     # thin claude.ai cache).
-                    home / "Library/Application Support/Claude/local-agent-mode-sessions",
+                    home
+                    / "Library/Application Support/Claude/local-agent-mode-sessions",
                 ]
             )
 

--- a/libs/collectors/claude_collector.py
+++ b/libs/collectors/claude_collector.py
@@ -37,6 +37,10 @@ class ClaudeDesktopCollector(BaseCollector):
                     home / "Library/Application Support/Claude/Session Storage",
                     home / "Library/Application Support/Claude/IndexedDB",
                     home / "Library/Application Support/Claude/Local Storage",
+                    # Local Agent Mode keeps full transcripts as audit.jsonl per
+                    # session (the IndexedDB/Local Storage paths above only hold a
+                    # thin claude.ai cache).
+                    home / "Library/Application Support/Claude/local-agent-mode-sessions",
                 ]
             )
 
@@ -71,7 +75,15 @@ class ClaudeDesktopCollector(BaseCollector):
             logger.info(f"Checking path: {data_path}")
 
             # Try different storage types
-            if "Session Storage" in str(data_path):
+            if "local-agent-mode-sessions" in str(data_path):
+                conversations = self._collect_from_agent_mode(data_path, since_date)
+                all_conversations.extend(conversations)
+                # audit.jsonl is the authoritative transcript; skip the generic
+                # JSON-export glob below for this tree (session metadata files
+                # are not standalone conversations).
+                continue
+
+            elif "Session Storage" in str(data_path):
                 conversations = self._collect_from_session_storage(
                     data_path, since_date
                 )
@@ -109,6 +121,125 @@ class ClaudeDesktopCollector(BaseCollector):
             f"Collected {len(all_conversations)} conversations from {self.source_name}"
         )
         return all_conversations
+
+    def _collect_from_agent_mode(
+        self, base_path: Path, since_date: Optional[datetime]
+    ) -> List[Conversation]:
+        """Collect Local Agent Mode transcripts.
+
+        Each session is `.../local_<uuid>/audit.jsonl` (a JSONL event log) with a
+        sibling `local_<uuid>.json` metadata file. We keep the human turns and the
+        assistant's text blocks; tool_use / tool_result / thinking / system events
+        are skipped so the transcript reads as a real conversation.
+        """
+        conversations: List[Conversation] = []
+        for audit in base_path.glob("**/local_*/audit.jsonl"):
+            try:
+                conv = self._parse_agent_mode_session(audit)
+                if conv and conv.messages:
+                    conversations.append(conv)
+            except Exception as exc:  # one bad session must not abort the rest
+                logger.warning("Failed to parse agent-mode session %s: %s", audit, exc)
+                self.stats["errors"] += 1
+        logger.info("Extracted %d agent-mode sessions", len(conversations))
+        return conversations
+
+    @staticmethod
+    def _agent_mode_text(content: Any) -> str:
+        """Flatten a message 'content' (str, or list of blocks) to plain text."""
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts = [
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            ]
+            return "\n".join(p for p in parts if p).strip()
+        return ""
+
+    def _parse_agent_mode_session(self, audit_path: Path) -> Optional[Conversation]:
+        # Sibling metadata file: .../local_<uuid>.json next to .../local_<uuid>/
+        meta_path = audit_path.parent.with_suffix(".json")
+        meta: Dict[str, Any] = {}
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.debug("agent-mode meta unreadable %s: %s", meta_path, exc)
+
+        def epoch_ms(value: Any) -> Optional[datetime]:
+            try:
+                return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
+            except (TypeError, ValueError):
+                return None
+
+        created_at = epoch_ms(meta.get("createdAt"))
+        updated_at = epoch_ms(meta.get("lastActivityAt")) or created_at
+        session_id = meta.get("sessionId") or audit_path.parent.name
+        title = meta.get("title")
+        model = meta.get("model")
+
+        messages: List[Message] = []
+        prev_key: Optional[tuple] = None
+        with open(audit_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("type") not in ("user", "assistant"):
+                    continue
+                msg = event.get("message") or {}
+                role = msg.get("role")
+                if role not in ("user", "assistant"):
+                    continue
+                text = self._agent_mode_text(msg.get("content"))
+                if not text:
+                    continue  # tool_result / tool_use / thinking-only turn
+                key = (role, text)
+                if key == prev_key:
+                    continue  # collapse the occasional duplicated turn
+                prev_key = key
+                ts = self.normalize_timestamp(
+                    event.get("_audit_timestamp")
+                    or updated_at
+                    or datetime.now(timezone.utc)
+                )
+                messages.append(
+                    Message(
+                        role=role,
+                        content=text,
+                        timestamp=ts,
+                        metadata={"model": model} if model else {},
+                    )
+                )
+
+        if not messages:
+            return None
+        if not created_at:
+            created_at = messages[0].timestamp
+        if not updated_at:
+            updated_at = messages[-1].timestamp
+        if not title:
+            title = self.extract_title({"messages": messages})
+
+        conv_meta: Dict[str, Any] = {"agent_mode": True}
+        if model:
+            conv_meta["model"] = model
+        return Conversation(
+            id=session_id,
+            source=self.source_name,
+            title=title,
+            messages=messages,
+            created_at=created_at,
+            updated_at=updated_at,
+            thread_id=session_id,
+            metadata=conv_meta,
+        )
 
     def _collect_from_session_storage(
         self, storage_path: Path, since_date: Optional[datetime]

--- a/libs/collectors/cursor_collector.py
+++ b/libs/collectors/cursor_collector.py
@@ -191,9 +191,7 @@ class CursorCollector(BaseCollector):
         # *cursor*/*ai* subdir scan below misses these entirely.
         state_db = storage_path / "state.vscdb"
         if state_db.exists():
-            conversations.extend(
-                self._collect_from_cursordiskkv(state_db, since_date)
-            )
+            conversations.extend(self._collect_from_cursordiskkv(state_db, since_date))
 
         # Look for Cursor AI extension data
         cursor_dirs = list(storage_path.glob("*cursor*"))

--- a/libs/collectors/cursor_collector.py
+++ b/libs/collectors/cursor_collector.py
@@ -186,6 +186,15 @@ class CursorCollector(BaseCollector):
         """Collect from global storage"""
         conversations = []
 
+        # Modern Cursor stores composer/agent chats in globalStorage/state.vscdb
+        # under the cursorDiskKV table (composerData:* + bubbleId:*). The legacy
+        # *cursor*/*ai* subdir scan below misses these entirely.
+        state_db = storage_path / "state.vscdb"
+        if state_db.exists():
+            conversations.extend(
+                self._collect_from_cursordiskkv(state_db, since_date)
+            )
+
         # Look for Cursor AI extension data
         cursor_dirs = list(storage_path.glob("*cursor*"))
         cursor_dirs.extend(list(storage_path.glob("*ai*")))
@@ -206,6 +215,108 @@ class CursorCollector(BaseCollector):
                     convs = self._collect_from_json(json_file, since_date)
                     conversations.extend(convs)
 
+        return conversations
+
+    @staticmethod
+    def _cursor_epoch(value: Any) -> datetime:
+        try:
+            return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
+        except (TypeError, ValueError):
+            return datetime.now(timezone.utc)
+
+    def _collect_from_cursordiskkv(
+        self, db_file: Path, since_date: Optional[datetime]
+    ) -> List[Conversation]:
+        """Collect modern Cursor composer chats from the cursorDiskKV table.
+
+        composerData:<cid> holds metadata + an ordered fullConversationHeadersOnly
+        list of {bubbleId, type}; each bubbleId:<cid>:<bid> row holds one message
+        (type "1"=user, "2"=assistant) with its text.
+        """
+        conversations: List[Conversation] = []
+        try:
+            conn = sqlite3.connect(f"file:{db_file}?mode=ro", uri=True)
+        except Exception as exc:
+            logger.debug("cursorDiskKV open failed %s: %s", db_file, exc)
+            return conversations
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'"
+            )
+            if not cur.fetchone():
+                return conversations  # older Cursor without this table
+
+            cur.execute(
+                "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+            )
+            for key, value in cur.fetchall():
+                try:
+                    data = json.loads(value)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                cid = data.get("composerId") or key.split(":", 1)[-1]
+                headers = data.get("fullConversationHeadersOnly")
+                if not isinstance(headers, list) or not headers:
+                    continue
+
+                messages: List[Message] = []
+                for hdr in headers:
+                    if not isinstance(hdr, dict):
+                        continue
+                    bid = hdr.get("bubbleId")
+                    if not bid:
+                        continue
+                    cur.execute(
+                        "SELECT value FROM cursorDiskKV WHERE key = ?",
+                        (f"bubbleId:{cid}:{bid}",),
+                    )
+                    row = cur.fetchone()
+                    if not row:
+                        continue
+                    try:
+                        bubble = json.loads(row[0])
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    text = (bubble.get("text") or "").strip()
+                    if not text:
+                        continue  # tool/diff/empty bubble
+                    role = "user" if str(bubble.get("type")) == "1" else "assistant"
+                    messages.append(
+                        Message(
+                            role=role,
+                            content=text,
+                            timestamp=datetime.now(timezone.utc),
+                        )
+                    )
+
+                if not messages:
+                    continue
+
+                created_at = self._cursor_epoch(data.get("createdAt"))
+                title = (data.get("name") or "").strip() or self.extract_title(
+                    {"messages": messages}
+                )
+                conversations.append(
+                    Conversation(
+                        id=cid,
+                        source=self.source_name,
+                        title=title,
+                        messages=messages,
+                        created_at=created_at,
+                        updated_at=self._cursor_epoch(data.get("lastUpdatedAt"))
+                        or created_at,
+                        thread_id=cid,
+                        metadata={"composer": True},
+                    )
+                )
+        finally:
+            conn.close()
+        logger.info(
+            "Extracted %d Cursor composer chats from %s",
+            len(conversations),
+            db_file.name,
+        )
         return conversations
 
     def _collect_from_local_storage(

--- a/scripts/collect-conversations.py
+++ b/scripts/collect-conversations.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Collect conversations from a local source and POST them to the MindBase API.
+
+This is the Python counterpart to `apps/cli/commands/collect.ts` (which only
+handles claude-code). collect.ts points other sources here. It runs on the HOST
+(not in a container) because the collectors read host paths like
+~/Library/Application Support/... and ~/.claude.
+
+Usage:
+    python scripts/collect-conversations.py --source chatgpt --dry-run
+    python scripts/collect-conversations.py --source cursor --since 2024-01-01
+    python scripts/collect-conversations.py --source chatgpt \
+        --export-file ~/Downloads/chatgpt-export/conversations.json
+
+Sources: chatgpt | claude-desktop | claude-code | cursor | windsurf | gemini
+
+The API URL defaults to the host-published port from .env (18002). Override with
+--api-url or MINDBASE_API_URL.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make `libs.collectors.*` importable when run from the repo root on the host.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from libs.collectors.base_collector import Conversation  # noqa: E402
+
+# source name -> (module, class)
+COLLECTORS = {
+    "chatgpt": ("libs.collectors.chatgpt_collector", "ChatGPTCollector"),
+    "claude-desktop": ("libs.collectors.claude_collector", "ClaudeDesktopCollector"),
+    "claude-code": ("libs.collectors.claude_code_collector", "ClaudeCodeCollector"),
+    "cursor": ("libs.collectors.cursor_collector", "CursorCollector"),
+    "windsurf": ("libs.collectors.windsurf_collector", "WindsurfCollector"),
+    "gemini": ("libs.collectors.gemini_collector", "GeminiCollector"),
+}
+
+
+def load_collector(source: str):
+    import importlib
+
+    if source not in COLLECTORS:
+        raise SystemExit(
+            f"Unknown source '{source}'. Choices: {', '.join(COLLECTORS)}"
+        )
+    mod_name, cls_name = COLLECTORS[source]
+    mod = importlib.import_module(mod_name)
+    return getattr(mod, cls_name)()
+
+
+def to_payload(conv: Conversation) -> dict:
+    """Map a collector Conversation dataclass to the API ConversationCreate body."""
+    messages = []
+    for m in conv.messages:
+        ts = getattr(m, "timestamp", None)
+        messages.append(
+            {
+                "role": m.role,
+                "content": m.content,
+                "timestamp": ts.isoformat() if isinstance(ts, datetime) else None,
+            }
+        )
+    metadata = dict(conv.metadata or {})
+    if conv.project:
+        metadata.setdefault("project", conv.project)
+    if conv.workspace:
+        metadata.setdefault("workspace", conv.workspace)
+    if conv.tags:
+        metadata.setdefault("tags", conv.tags)
+    return {
+        "source": conv.source,
+        "source_conversation_id": conv.thread_id or conv.id,
+        "title": conv.title,
+        "content": {"messages": messages},
+        "metadata": metadata,
+        "source_created_at": conv.created_at.isoformat() if conv.created_at else None,
+    }
+
+
+def post_conversation(api_url: str, payload: dict, timeout: float = 60.0) -> tuple[bool, str]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{api_url.rstrip('/')}/conversations/store",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return True, f"{resp.status}"
+    except urllib.error.HTTPError as e:
+        return False, f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:300]}"
+    except Exception as e:  # noqa: BLE001 — surface the failure, never swallow it
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--source", required=True, choices=list(COLLECTORS))
+    ap.add_argument("--since", help="ISO date, e.g. 2024-01-01 — only newer conversations")
+    ap.add_argument("--limit", type=int, default=0, help="Max conversations to send (0 = all)")
+    ap.add_argument("--dry-run", action="store_true", help="Collect and report, do not POST")
+    ap.add_argument(
+        "--export-file",
+        help="Path to an official export JSON (ChatGPT/Claude). Overrides default scan paths.",
+    )
+    ap.add_argument(
+        "--api-url",
+        default=os.environ.get("MINDBASE_API_URL", "http://localhost:18002"),
+    )
+    args = ap.parse_args()
+
+    since = None
+    if args.since:
+        since = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+
+    collector = load_collector(args.source)
+
+    # Official exports: feed the file directly through the collector's JSON path.
+    if args.export_file:
+        export_path = Path(args.export_file).expanduser()
+        if not export_path.exists():
+            raise SystemExit(f"--export-file not found: {export_path}")
+        if not hasattr(collector, "_collect_from_json"):
+            raise SystemExit(
+                f"{args.source} collector has no JSON-export path (_collect_from_json)."
+            )
+        conversations = collector._collect_from_json(export_path, since)
+    else:
+        conversations = collector.collect(since)
+
+    print(f"[{args.source}] collected {len(conversations)} conversations")
+    if args.limit:
+        conversations = conversations[: args.limit]
+        print(f"[{args.source}] limited to {len(conversations)}")
+
+    if args.dry_run:
+        for c in conversations[:5]:
+            n = len(c.messages)
+            when = c.created_at.date().isoformat() if c.created_at else "?"
+            print(f"  - [{when}] {(c.title or '(untitled)')[:70]}  ({n} msgs)")
+        if len(conversations) > 5:
+            print(f"  ... and {len(conversations) - 5} more")
+        return 0
+
+    ok = 0
+    fail = 0
+    for i, conv in enumerate(conversations, 1):
+        success, info = post_conversation(args.api_url, to_payload(conv))
+        if success:
+            ok += 1
+        else:
+            fail += 1
+            print(f"  ! [{i}/{len(conversations)}] {conv.title!r}: {info}")
+        if i % 25 == 0:
+            print(f"  ... {i}/{len(conversations)} (ok={ok} fail={fail})")
+    print(f"[{args.source}] done: stored={ok} failed={fail}")
+    return 1 if fail and ok == 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `claude_collector.py`: adds Local Agent Mode support — scans `~/Library/Application Support/Claude/local-agent-mode-sessions/**/audit.jsonl`, parses the JSONL event stream keeping only user/assistant text turns, reads sibling `local_<uuid>.json` for title/timestamps/model.
- `cursor_collector.py`: adds `_collect_from_cursordiskkv()` — reads the modern Cursor `globalStorage/state.vscdb` `cursorDiskKV` table (`composerData:*` + `bubbleId:*` keys) to extract composer/agent chats that the legacy `*cursor*/*ai*` subdir scan misses. Opens DB read-only via `sqlite3 uri=True mode=ro`.
- `scripts/collect-conversations.py` (new): host-native Python script that loads a collector by source name and POSTs conversations to the MindBase API. Supports `--source`, `--since`, `--limit`, `--dry-run`, `--export-file`, `--api-url`. Runs on the host (not in Docker) because collectors read host paths.

## Files

- `libs/collectors/claude_collector.py` (modified)
- `libs/collectors/cursor_collector.py` (modified)
- `scripts/collect-conversations.py` (new)

## Dependency order

No upstream dependencies. Independent of the other PRs in this batch.