### PR TITLE
fix(ci): green main — SUMMARY_MODEL test env + black format + fix app→apps.api imports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ EMBEDDING_PROVIDER=ollama
 OLLAMA_HOST=localhost
 OLLAMA_PORT=11434
 EMBEDDING_MODEL=bge-m3
+# Chat model for Japanese session summarisation (generative, not embedding).
+# Must be present on the Ollama instance.
+SUMMARY_MODEL=qwen3:14b
 # Head-truncate embedding input to this many chars (models have a fixed context
 # window and error on overflow). On overflow the input is halved and retried.
 EMBEDDING_MAX_CHARS=8000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://mindbase:mindbase_dev@localhost:5432/mindbase_test
           OLLAMA_URL: http://localhost:11434
+          EMBEDDING_MODEL: qwen3-embedding:8b
+          EMBEDDING_DIMENSIONS: 4096
+          SUMMARY_MODEL: qwen3:14b
         run: uv run pytest tests/ -v
 
       - name: Run TypeScript type check

--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -6,11 +6,11 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import get_settings
-from app import crud
-from app.database import get_db
-from app.ollama_client import ollama_client
-from app.schemas.conversation import (
+from apps.api.config import get_settings
+from apps.api import crud
+from apps.api.database import get_db
+from apps.api.ollama_client import ollama_client
+from apps.api.schemas.conversation import (
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
@@ -19,7 +19,10 @@ from app.schemas.conversation import (
     SearchQuery,
     SearchResult,
 )
-from app.services.deriver import _extract_text_from_content, process_raw_conversation
+from apps.api.services.deriver import (
+    _extract_text_from_content,
+    process_raw_conversation,
+)
 
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 logger = logging.getLogger(__name__)
@@ -115,7 +118,9 @@ async def search_conversations_endpoint(
             # records ingested before summary generation was added.
             row_summary = getattr(row, "summary", None)
             if row_summary:
-                preview = row_summary[:200] + "..." if len(row_summary) > 200 else row_summary
+                preview = (
+                    row_summary[:200] + "..." if len(row_summary) > 200 else row_summary
+                )
             elif "messages" in row.content:
                 messages = row.content["messages"]
                 first_message = messages[0].get("content", "") if messages else ""

--- a/apps/api/crud/__init__.py
+++ b/apps/api/crud/__init__.py
@@ -3,8 +3,6 @@
 from apps.api.crud.conversation import (
     create_conversation_record,
     create_raw_conversation,
-    get_conversation,
-    list_conversations,
 )
 from apps.api.crud.search import search_conversations
 from apps.api.crud.embeddings import (
@@ -18,8 +16,6 @@ from apps.api.crud.embeddings import (
 __all__ = [
     "create_raw_conversation",
     "create_conversation_record",
-    "get_conversation",
-    "list_conversations",
     "search_conversations",
     "column_for_dim",
     "count_conversations_missing_embedding",

--- a/apps/api/crud/conversation.py
+++ b/apps/api/crud/conversation.py
@@ -9,8 +9,8 @@ from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.conversation import Conversation, RawConversation
-from app.schemas.conversation import ConversationCreate
+from apps.api.models.conversation import Conversation, RawConversation
+from apps.api.schemas.conversation import ConversationCreate
 
 
 async def create_raw_conversation(

--- a/apps/api/models/conversation.py
+++ b/apps/api/models/conversation.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
-from app.database import Base
+from apps.api.database import Base
 
 
 class RawConversation(Base):

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -16,8 +16,8 @@ from typing import Iterable, List, Tuple
 
 import httpx
 
-from app.config import get_settings
-from app.services.model_manager import ModelManager
+from apps.api.config import get_settings
+from apps.api.services.model_manager import ModelManager
 
 logger = logging.getLogger(__name__)
 

--- a/apps/api/services/deriver.py
+++ b/apps/api/services/deriver.py
@@ -8,13 +8,13 @@ from typing import Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import crud
-from app.config import get_settings
-from app.models.conversation import RawConversation
-from app.ollama_client import ollama_client
-from app.schemas.conversation import ConversationCreate, ConversationResponse
-from app.services.classifier import infer_project, infer_topics
-from app.services.pipelines import run_post_derivation
+from apps.api import crud
+from apps.api.config import get_settings
+from apps.api.models.conversation import RawConversation
+from apps.api.ollama_client import ollama_client
+from apps.api.schemas.conversation import ConversationCreate, ConversationResponse
+from apps.api.services.classifier import infer_project, infer_topics
+from apps.api.services.pipelines import run_post_derivation
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## 根因

#37 が CI を3点壊した:

1. **Run Tests (ValidationError)** — `SUMMARY_MODEL` を `Settings` の必須フィールドとして追加したが、`test.yml` の pytest step に env 供給がなく、conftest 内 `Settings()` 構築で `ValidationError` (exit 4)。
2. **Lint / black** — `conversations.py` が black 未整形。
3. **隠れた import 破損** — #37 は PR #29 (app シンボリックリンク削除) より前のブランチで開発されており、`from app.` / `from app import crud` の旧パスが再混入。加えて `crud/__init__.py` が `get_conversation` / `list_conversations` を宣言しているが実装が存在せず `ImportError`。

## 直した内容

| ファイル | 変更 |
|---|---|
| `.github/workflows/test.yml` | pytest step env に `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`, `SUMMARY_MODEL` を追加 |
| `apps/api/api/routes/conversations.py` | `from app import crud` → `from apps.api import crud`; black 整形 |
| `apps/api/crud/__init__.py` | 存在しない `get_conversation`/`list_conversations` のインポート/`__all__` を削除 |
| `apps/api/crud/conversation.py` | `from app.` → `from apps.api.` |
| `apps/api/models/conversation.py` | `from app.database import Base` → `from apps.api.database import Base` |
| `apps/api/ollama_client.py` | `from app.` → `from apps.api.` |
| `apps/api/services/deriver.py` | `from app import crud` → `from apps.api import crud`; `from app.` → `from apps.api.` |
| `.env.example` | `SUMMARY_MODEL` を必須変数として追記 |

## ローカル検証

- `uv run black --check apps/api/ libs/collectors/` → exit 0 (44 files unchanged)
- `DATABASE_URL=... EMBEDDING_MODEL=qwen3-embedding:8b EMBEDDING_DIMENSIONS=4096 SUMMARY_MODEL=qwen3:14b uv run pytest tests/ --collect-only` → **25 tests collected, 0 errors**