### PR TITLE
fix(recall): rebuild summary on current main (undo stale-base clobber)

### DIFF
--- a/apps/api/api/routes/conversations.py
+++ b/apps/api/api/routes/conversations.py
@@ -2,8 +2,9 @@
 
 import logging
 from datetime import datetime
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.config import get_settings
@@ -11,14 +12,19 @@ from apps.api import crud
 from apps.api.database import get_db
 from apps.api.ollama_client import ollama_client
 from apps.api.schemas.conversation import (
+    CompareModelResults,
+    CompareRequest,
+    CompareResponse,
     ConversationCreate,
     ConversationQueuedResponse,
     ConversationResponse,
+    ConversationSummary,
     ReembedRequest,
     ReembedResponse,
     SearchQuery,
     SearchResult,
 )
+from apps.api.services import settings_store
 from apps.api.services.deriver import (
     _extract_text_from_content,
     process_raw_conversation,
@@ -27,6 +33,80 @@ from apps.api.services.deriver import (
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+
+def _format_result(row) -> SearchResult:
+    """Map a search row to a SearchResult with a short content preview.
+
+    Prefers the AI-generated summary when available; falls back to the first
+    message content for conversations ingested before summary generation.
+    """
+    if getattr(row, "summary", None):
+        raw = row.summary
+        preview = raw[:200] + "..." if len(raw) > 200 else raw
+    elif "messages" in row.content:
+        messages = row.content["messages"]
+        first_message = messages[0].get("content", "") if messages else ""
+        preview = (
+            first_message[:200] + "..." if len(first_message) > 200 else first_message
+        )
+    else:
+        content_str = str(row.content)
+        preview = content_str[:200] + "..." if len(content_str) > 200 else content_str
+    return SearchResult(
+        id=row.id,
+        title=row.title,
+        source=row.source,
+        project=row.project,
+        topics=row.topics or [],
+        similarity=row.similarity,
+        workspace_path=row.workspace_path,
+        raw_id=row.raw_id,
+        created_at=row.created_at,
+        content_preview=preview,
+    )
+
+
+@router.get("", response_model=list[ConversationSummary])
+async def list_conversations_endpoint(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    source: str | None = Query(None),
+    project: str | None = Query(None),
+):
+    """List derived conversations (newest first). Backend is the store-of-record,
+    so clients render this instead of keeping their own local copy."""
+    rows = await crud.list_conversations(
+        db, limit=limit, offset=offset, source=source, project=project
+    )
+    return [ConversationSummary.model_validate(row) for row in rows]
+
+
+@router.get("/{conversation_id}", response_model=ConversationResponse)
+async def get_conversation_endpoint(
+    conversation_id: UUID, db: AsyncSession = Depends(get_db)
+):
+    """Fetch a single conversation with its full content payload."""
+    row = await crud.get_conversation(db, conversation_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return ConversationResponse(
+        id=row.id,
+        raw_id=row.raw_id,
+        source=row.source,
+        source_conversation_id=row.source_conversation_id,
+        title=row.title,
+        content=row.content,
+        metadata=row.conv_metadata or {},
+        message_count=row.message_count,
+        project=row.project,
+        topics=row.topics or [],
+        workspace_path=row.workspace_path,
+        summary=row.summary,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
 
 
 @router.post("/store", response_model=ConversationResponse | ConversationQueuedResponse)
@@ -90,9 +170,16 @@ async def search_conversations_endpoint(
     """
     try:
         # Resolve provider/model: the query must be embedded with the same model
-        # whose stored vectors we search against.
-        provider = query.provider or ollama_client.active_provider
-        model = query.model or ollama_client.default_model(provider)
+        # whose stored vectors we search against. Defaults come from the active
+        # embedding (single source of truth), overridable per request.
+        active_provider, active_model = settings_store.get_active_embedding()
+        provider = query.provider or active_provider
+        if query.model:
+            model = query.model
+        elif provider == active_provider:
+            model = active_model
+        else:
+            model = ollama_client.default_model(provider)
 
         query_embedding = await ollama_client.embed(
             query.query, provider=provider, model=model
@@ -111,50 +198,60 @@ async def search_conversations_endpoint(
             workspace_path=query.workspace_path,
         )
 
-        # Format results
-        search_results = []
-        for row in results:
-            # Prefer the AI-generated summary; fall back to first message for
-            # records ingested before summary generation was added.
-            row_summary = getattr(row, "summary", None)
-            if row_summary:
-                preview = (
-                    row_summary[:200] + "..." if len(row_summary) > 200 else row_summary
-                )
-            elif "messages" in row.content:
-                messages = row.content["messages"]
-                first_message = messages[0].get("content", "") if messages else ""
-                preview = (
-                    first_message[:200] + "..."
-                    if len(first_message) > 200
-                    else first_message
-                )
-            else:
-                content_str = str(row.content)
-                preview = (
-                    content_str[:200] + "..." if len(content_str) > 200 else content_str
-                )
-
-            search_results.append(
-                SearchResult(
-                    id=row.id,
-                    title=row.title,
-                    source=row.source,
-                    project=row.project,
-                    topics=row.topics or [],
-                    similarity=row.similarity,
-                    workspace_path=row.workspace_path,
-                    raw_id=row.raw_id,
-                    created_at=row.created_at,
-                    content_preview=preview,
-                )
-            )
-
-        return search_results
+        return [_format_result(row) for row in results]
 
     except Exception as exc:  # pragma: no cover
         logger.exception("Failed to search conversations")
         raise HTTPException(status_code=500, detail=f"Search failed: {exc}") from exc
+
+
+@router.post("/compare", response_model=CompareResponse)
+async def compare_models(request: CompareRequest, db: AsyncSession = Depends(get_db)):
+    """
+    Run one query against several embedding models, side by side.
+
+    Each model embeds the query and searches only its own stored vectors
+    (per-model coexistence in conversation_embeddings), so you can eyeball recall
+    and ranking differences for accuracy validation. Backfill coverage first with
+    POST /conversations/reembed. A model that can't be embedded yields an `error`
+    entry instead of failing the whole comparison.
+    """
+    models_out: list[CompareModelResults] = []
+    for spec in request.models:
+        provider = spec.provider
+        model = spec.model or ollama_client.default_model(provider)
+        try:
+            query_embedding = await ollama_client.embed(
+                request.query, provider=provider, model=model
+            )
+            rows = await crud.search_conversation_embeddings(
+                db=db,
+                query_embedding=query_embedding,
+                provider=provider,
+                model=model,
+                limit=request.limit,
+                threshold=request.threshold,
+                source=request.source,
+                project=request.project,
+                topic=request.topic,
+                workspace_path=request.workspace_path,
+            )
+            models_out.append(
+                CompareModelResults(
+                    provider=provider,
+                    model=model,
+                    results=[_format_result(row) for row in rows],
+                )
+            )
+        except Exception as exc:  # pragma: no cover - per-model isolation
+            logger.exception("compare: model %s/%s failed", provider, model)
+            models_out.append(
+                CompareModelResults(
+                    provider=provider, model=model, results=[], error=str(exc)
+                )
+            )
+
+    return CompareResponse(query=request.query, models=models_out)
 
 
 @router.post("/reembed", response_model=ReembedResponse)

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -27,12 +27,27 @@ class Settings(BaseSettings):
 
     # Ollama Embedding
     OLLAMA_URL: str
-    EMBEDDING_MODEL: str
-    EMBEDDING_DIMENSIONS: int
+    # Seed default for the active embedding model. The live source of truth is the
+    # settings store (services/settings_store.get_active_embedding); this env value
+    # only seeds it when the store has no choice yet.
+    EMBEDDING_MODEL: str = "bge-m3"
+    # Vestigial: the real dimension is derived from the embedding vector length
+    # (crud.column_for_dim). Kept only for the legacy conversations.embedding column.
+    EMBEDDING_DIMENSIONS: int = 1024
+
+    # Chat (LLM) — seed defaults only. The live source of truth is the settings
+    # store (services/settings_store.get_chat_settings); these seed it when unset.
+    CHAT_MODEL: str = "qwen2.5:3b"
+    CHAT_TEMPERATURE: float = 0.7
+    CHAT_MAX_TOKENS: int = 2048
+    CHAT_SYSTEM_PROMPT: str = (
+        "You are MindBase, a helpful assistant with access to the user's past "
+        "conversations. Use the provided context when relevant."
+    )
 
     # Ollama chat model for Japanese session summarisation.
     # Must be a model present on the Ollama instance (not an embedding model).
-    SUMMARY_MODEL: str
+    SUMMARY_MODEL: str = "qwen3:14b"
 
     # Max characters of input text per embedding call. Embedding models have a
     # fixed context window (bge-m3: 8192 tokens) and error on overflow, so long

--- a/apps/api/crud/__init__.py
+++ b/apps/api/crud/__init__.py
@@ -3,6 +3,8 @@
 from apps.api.crud.conversation import (
     create_conversation_record,
     create_raw_conversation,
+    get_conversation,
+    list_conversations,
 )
 from apps.api.crud.search import search_conversations
 from apps.api.crud.embeddings import (
@@ -16,6 +18,8 @@ from apps.api.crud.embeddings import (
 __all__ = [
     "create_raw_conversation",
     "create_conversation_record",
+    "get_conversation",
+    "list_conversations",
     "search_conversations",
     "column_for_dim",
     "count_conversations_missing_embedding",

--- a/apps/api/crud/conversation.py
+++ b/apps/api/crud/conversation.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import List, Optional
+from uuid import UUID
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -56,13 +57,8 @@ async def create_conversation_record(
     Uses ON CONFLICT (source, source_conversation_id) DO UPDATE so that
     re-storing the same source conversation updates content, summary, and
     timestamps rather than raising a unique-constraint violation.
-
-    Note: conv_metadata maps to the DB column "metadata" (Column("metadata", ...)).
-    The excluded pseudo-table uses DB column names, so we reference "metadata" there.
     """
 
-    # Build the INSERT using DB column names for columns that have an alias.
-    # conv_metadata → DB column "metadata"; pass via model's mapped attr in values().
     insert_stmt = pg_insert(Conversation).values(
         raw_id=raw_record.id,
         source=conversation.source,
@@ -71,7 +67,7 @@ async def create_conversation_record(
         title=conversation.title,
         content=conversation.content,
         raw_content=raw_content,
-        conv_metadata=metadata,  # ORM attr name maps to "metadata" column
+        conv_metadata=metadata,
         source_created_at=conversation.source_created_at,
         embedding=embedding,
         message_count=message_count,
@@ -83,12 +79,10 @@ async def create_conversation_record(
     upsert_stmt = insert_stmt.on_conflict_do_update(
         index_elements=[Conversation.source, Conversation.source_conversation_id],
         set_={
-            # Use DB column names for excluded references.
-            # conv_metadata → "metadata"; all others match the Python attr name.
             "raw_id": insert_stmt.excluded.raw_id,
             "content": insert_stmt.excluded.content,
             "raw_content": insert_stmt.excluded.raw_content,
-            "metadata": insert_stmt.excluded.metadata,  # DB col name, not Python attr
+            "metadata": insert_stmt.excluded.metadata,
             "message_count": insert_stmt.excluded.message_count,
             "title": insert_stmt.excluded.title,
             "project": insert_stmt.excluded.project,
@@ -99,11 +93,37 @@ async def create_conversation_record(
     ).returning(Conversation.id)
 
     result = await db.execute(upsert_stmt)
-    conversation_id = result.scalar_one()
+    row = result.fetchone()
     await db.flush()
 
-    fetched = await db.execute(
+    fetched = await db.execute(select(Conversation).where(Conversation.id == row[0]))
+    return fetched.scalar_one()
+
+
+async def list_conversations(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+    source: Optional[str] = None,
+    project: Optional[str] = None,
+) -> List[Conversation]:
+    """Return derived conversations, newest first (backend is the store-of-record)."""
+    stmt = select(Conversation).order_by(Conversation.created_at.desc())
+    if source:
+        stmt = stmt.where(Conversation.source == source)
+    if project:
+        stmt = stmt.where(Conversation.project == project)
+    stmt = stmt.limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_conversation(
+    db: AsyncSession, conversation_id: UUID
+) -> Optional[Conversation]:
+    """Fetch a single derived conversation by id (with its full content payload)."""
+    result = await db.execute(
         select(Conversation).where(Conversation.id == conversation_id)
     )
-    db_conversation = fetched.scalar_one()
-    return db_conversation
+    return result.scalar_one_or_none()

--- a/apps/api/ollama_client.py
+++ b/apps/api/ollama_client.py
@@ -11,8 +11,9 @@ Model management (pull, delete, list) is delegated to services/model_manager.py.
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Iterable, List, Tuple
+from typing import AsyncIterator, Iterable, List, Tuple
 
 import httpx
 
@@ -176,6 +177,36 @@ class EmbeddingClient:
             return [await self._ollama_embed(text, mdl) for text in text_list]
         raise ValueError(f"Unknown embedding provider: {prov!r}")
 
+    async def chat(
+        self,
+        messages: List[dict],
+        model: str,
+        options: dict | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream an Ollama chat completion, yielding content deltas.
+
+        Chat orchestration (RAG, prompt assembly, persistence) lives in the API
+        route; this is just the transport so the LLM call stays on the server and
+        clients never talk to Ollama directly.
+        """
+        url = f"{self.ollama_url}/api/chat"
+        payload: dict = {"model": model, "messages": messages, "stream": True}
+        if options:
+            payload["options"] = options
+
+        async with httpx.AsyncClient(timeout=300.0) as client:
+            async with client.stream("POST", url, json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    delta = (data.get("message") or {}).get("content")
+                    if delta:
+                        yield delta
+                    if data.get("done"):
+                        break
+
     async def health_check(self) -> bool:
         """Return True if the active provider responds successfully."""
         if self.provider == OPENAI:
@@ -230,13 +261,12 @@ class EmbeddingClient:
             )
             response.raise_for_status()
             data = response.json()
-
-        summary = data.get("response")
-        if summary is None:
+        result = data.get("response")
+        if result is None:
             raise ValueError(
-                f"Ollama /api/generate did not return 'response' field: {data}"
+                f"Ollama /api/generate did not return 'response': {data!r}"
             )
-        return summary.strip()
+        return result.strip()
 
     # ----------------------------------------------------- compatibility wraps
     async def generate_embedding(self, text: str) -> List[float]:

--- a/apps/api/schemas/conversation.py
+++ b/apps/api/schemas/conversation.py
@@ -85,6 +85,23 @@ class ConversationResponse(BaseModel):
         from_attributes = True
 
 
+class ConversationSummary(BaseModel):
+    """Lightweight conversation row for list views (no full content payload)."""
+
+    id: UUID
+    source: str
+    title: Optional[str]
+    project: Optional[str]
+    topics: List[str] = Field(default_factory=list)
+    message_count: int
+    workspace_path: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class ConversationQueuedResponse(BaseModel):
     """Schema returned when derivation is queued."""
 
@@ -112,6 +129,22 @@ class AppSettings(BaseModel):
     refreshIntervalMs: int = Field(
         15000, description="Menubar poll interval in milliseconds"
     )
+    # Active embedding selection — the single source of truth (persisted here).
+    # Null means "unset": the API seeds these from env defaults on read.
+    embeddingProvider: Optional[str] = Field(
+        None, description="Active embedding provider: 'ollama' | 'openai'"
+    )
+    embeddingModel: Optional[str] = Field(
+        None, description="Active embedding model name (from the model catalog)"
+    )
+    # Chat (LLM) selection — also a single source of truth, persisted here.
+    # Null means "unset": the API seeds these from env defaults on read.
+    chatModel: Optional[str] = Field(None, description="Active chat (LLM) model")
+    chatTemperature: Optional[float] = Field(
+        None, description="Chat sampling temperature"
+    )
+    chatMaxTokens: Optional[int] = Field(None, description="Chat max output tokens")
+    chatSystemPrompt: Optional[str] = Field(None, description="Chat system prompt")
     collectors: List[CollectorConfig] = Field(default_factory=list)
     pipelines: List[PipelineConfig] = Field(default_factory=list)
 
@@ -123,6 +156,26 @@ class CommandResult(BaseModel):
     returncode: int
     stdout: str
     stderr: str
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    """A chat turn. The backend resolves the model/params from the settings SSoT,
+    fetches RAG context, assembles the prompt, streams the LLM, and persists — so
+    the client just sends a message and renders the stream."""
+
+    message: str = Field(..., min_length=1, description="User message")
+    model: Optional[str] = Field(None, description="Override the active chat model")
+    history: List[ChatMessage] = Field(
+        default_factory=list, description="Prior turns in this session"
+    )
+    rag_limit: int = Field(3, ge=0, le=20, description="Past conversations to retrieve")
+    rag_threshold: float = Field(0.5, ge=0.0, le=1.0)
+    store: bool = Field(True, description="Persist this turn as a conversation")
 
 
 class SearchQuery(BaseModel):
@@ -176,6 +229,53 @@ class SearchResult(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class CompareModel(BaseModel):
+    """One (provider, model) pair to evaluate in a comparison."""
+
+    provider: str = Field("ollama", description="Embedding provider: 'ollama'|'openai'")
+    model: Optional[str] = Field(
+        None, description="Model name; defaults to the provider's configured model"
+    )
+
+
+class CompareRequest(BaseModel):
+    """Run one query against several embedding models, side by side.
+
+    Each model searches only its own stored vectors (per-model coexistence in
+    conversation_embeddings). Backfill coverage first with POST /conversations/reembed
+    so every model has vectors to compare fairly.
+    """
+
+    query: str = Field(..., description="Search query text", min_length=1)
+    models: List[CompareModel] = Field(
+        ..., min_length=1, description="Models to compare for the same query"
+    )
+    limit: int = Field(10, ge=1, le=100)
+    threshold: float = Field(0.0, ge=0.0, le=1.0, description="Similarity threshold")
+    source: Optional[str] = None
+    project: Optional[str] = None
+    topic: Optional[str] = None
+    workspace_path: Optional[str] = None
+
+
+class CompareModelResults(BaseModel):
+    """Ranked results for a single model within a comparison."""
+
+    provider: str
+    model: str
+    results: List[SearchResult] = Field(default_factory=list)
+    error: Optional[str] = Field(
+        None, description="Set if this model could not be embedded/searched"
+    )
+
+
+class CompareResponse(BaseModel):
+    """Side-by-side comparison of several models over one query."""
+
+    query: str
+    models: List[CompareModelResults]
 
 
 class ReembedRequest(BaseModel):

--- a/apps/api/services/deriver.py
+++ b/apps/api/services/deriver.py
@@ -13,6 +13,7 @@ from apps.api.config import get_settings
 from apps.api.models.conversation import RawConversation
 from apps.api.ollama_client import ollama_client
 from apps.api.schemas.conversation import ConversationCreate, ConversationResponse
+from apps.api.services import settings_store
 from apps.api.services.classifier import infer_project, infer_topics
 from apps.api.services.pipelines import run_post_derivation
 
@@ -80,9 +81,10 @@ async def process_raw_conversation(
     # conversation_embeddings (keyed by provider/model), not the legacy
     # conversations.embedding column, so providers with different dimensions
     # can coexist.
-    provider = ollama_client.active_provider
-    model = ollama_client.active_model
-    embedding = await ollama_client.embed(text_content or " ")
+    provider, model = settings_store.get_active_embedding()
+    embedding = await ollama_client.embed(
+        text_content or " ", provider=provider, model=model
+    )
 
     project = infer_project(
         metadata=payload.metadata,


### PR DESCRIPTION
## Summary

PR #37 was built from a 15-commit-behind stale local checkout, clobbering symbols that main had added in those 15 commits. This PR restores BASE_GOOD (10920175 = main just before #37 merged) as foundation and re-applies the summary feature only.

**Clobbered symbols restored:**
- `schemas/conversation.py`: `ChatRequest`, `ChatMessage`, `ConversationSummary`, `AppSettings` embedding/chat fields
- `ollama_client.py`: `chat()` streaming method
- `crud/conversation.py`: `list_conversations`, `get_conversation`
- `api/routes/conversations.py`: list endpoint, `_format_result`, compare endpoints
- `config.py`: `CHAT_MODEL`/`CHAT_TEMPERATURE`/`CHAT_MAX_TOKENS`/`CHAT_SYSTEM_PROMPT` + `EMBEDDING_MODEL` defaults

**Summary additions re-applied cleanly on top:**
- `config.py`: `SUMMARY_MODEL: str = "qwen3:14b"` with safe default
- `schemas/conversation.py`: `summary: Optional[str] = None` on `ConversationResponse`
- `ollama_client.py`: `generate_summary(text, model)` via `/api/generate`
- `services/deriver.py`: `_generate_summary()` with try/except (failure → NULL, never blocks store)
- `crud/conversation.py`: upsert via `pg_insert ON CONFLICT (source, source_conversation_id)`
- `api/routes/conversations.py`: `_format_result` prefers summary over messages[0] fallback
- `crud/__init__.py`: re-export `list_conversations` and `get_conversation`

## Test plan

- [x] `ImportError: cannot import name 'ChatRequest'` resolved
- [x] `pytest tests/` → 25 passed, 0 failed
- [x] `black --check` → exit 0